### PR TITLE
Check if config keys are all defined in config_template keys

### DIFF
--- a/src/djtools/utils/config.py
+++ b/src/djtools/utils/config.py
@@ -61,7 +61,7 @@ def build_config():
         logger.info(f'Args: {args}')
         config.update(args)
 
-    # identify any required keys that are absent from the config
+    # identify misspelled or non-existing keys from the configuration file against the template
     config_template = ["USB_PATH", "AWS_PROFILE", "UPLOAD_INCLUDE_DIRS",
             "UPLOAD_EXCLUDE_DIRS", "DOWNLOAD_INCLUDE_DIRS",
             "DOWNLOAD_EXCLUDE_DIRS", "AWS_USE_DATE_MODIFIED",
@@ -78,9 +78,9 @@ def build_config():
             "AUTO_PLAYLIST_TOP_PERIOD", "AUTO_PLAYLIST_FUZZ_RATIO",
             "REDDIT_CLIENT_ID", "REDDIT_CLIENT_SECRET", "REDDIT_USER_AGENT",
             "VERBOSITY", "LOG_LEVEL"]
-    missing_config_keys = [k for k in config_template if k not in config]
-    if missing_config_keys:
-        msg = f'Config does not contain required keys: {missing_config_keys}'
+    unknown_config_keys = [k for k in config.keys() if k not in config_template]
+    if unknown_config_keys:
+        msg = f'Config does not contain required keys: {unknown_config_keys}'
         logger.critical(msg)
         raise ValueError(msg)
 


### PR DESCRIPTION
Suggestion: 
Minimal set of required vars in config file instead of having config files with all vars defined.
Check that vars are not misspelled/unknown.

Why:
- in most cases some config values will never be updated. Ex: `USER` should never be set in general.
- on the other hand some values have to change for each run when used (ex: `YOUTUBE_DL_URL`)
- if there's a new release with a new var that should not impact me I'd like to save myself updating the config file

So I feel it would make it easier to have a minimal set of config variables to define to run `djtools`.