### PR TITLE
Alex playlist builder one track per post

### DIFF
--- a/src/djtools/spotify/playlist_builder.py
+++ b/src/djtools/spotify/playlist_builder.py
@@ -197,10 +197,13 @@ def filter_results(spotify, results, threshold, title, artist):
         except Exception:
             logger.warning(f"Failed to get next tracks: {format_exc()}")
             break
-        tracks.append(filter_tracks(results['tracks']['items'], threshold,
-                                    title, artist))
+        result = filter_tracks(results['tracks']['items'], threshold, title,
+                               artist)
+        if result:
+            tracks.append(result)
+            break
 
-    return filter(None, tracks)
+    return tracks
 
 
 def filter_tracks(tracks, threshold, title, artist):


### PR DESCRIPTION
Former logic was to iterate all Spotify API track search results for a single subreddit submission and add all that matched sufficiently to the corresponding playlist...

This has been corrected to sort the filtered results by fuzz ratio between the track titles and take only the best match.