### PR TITLE
Alex xml track randomization

### DIFF
--- a/src/djtools/utils/README.md
+++ b/src/djtools/utils/README.md
@@ -97,7 +97,7 @@ Once the operation completes, an XML is generated at `XML_PATH` with the prefix 
 To trigger the `get_genres` modules, set `GET_GENRES: true`. The operation will print all the genres alphabetized with a count of tracks belonging to those genres. If `VERBOSITY` is increased, the individual tracks under each genre will be printed as well.
 
 ## randomize_tracks
-To trigger the `randomize_tracks` module, set `RANDOMIZE_TRACKS: true`. Once the operation has completed, you'll need to open Rekordbox and reimport the playlists that were randomized.
+To trigger the `randomize_tracks` module, set `RANDOMIZE_TRACKS: true`. Once the operation has completed, you'll need to open Rekordbox and reimport the `AUTO_RANDOMIZE` playlist containing the set of tracks with updated `TrackNumber` fields.
 
 ## youtube_dl
 To trigger the `youtube_dl` module, set `YOUTUBE_DL: true`. Once tracks are downloaded, make sure all file names adhere to convention:

--- a/src/djtools/utils/randomize_tracks.py
+++ b/src/djtools/utils/randomize_tracks.py
@@ -1,7 +1,7 @@
 """This module is used to emulate shuffling the track order of one or more
 playlists. This is done by setting the Rekordbox tag (i.e. 'TrackNumber') of
 tracks in the playlists to sequential numbers. After setting the TrackNumber
-tags of tracks in the provided playlists, those playlists must be reimported
+tags of tracks in the provided playlists, those tracks must be reimported
 for Rekordbox to be aware of the update.
 """
 from concurrent.futures import ThreadPoolExecutor
@@ -18,8 +18,8 @@ logger = logging.getLogger(__name__)
 
 def randomize_tracks(config):
     """For each playlist in 'RANDOMIZE_TRACKS_PLAYLISTS', shuffle the tracks
-    and sequentially set the 'RANDOMIZE_TRACKS_TAG' ID3 tag to a number to
-    emulate track randomization.
+    and sequentially set the TrackNumber tag to a number to emulate track
+    randomization.
 
     Args:
         config (dict): configuration object
@@ -43,10 +43,11 @@ def randomize_tracks(config):
             continue
         lookup[track['TrackID']] = track
 
+    seen_tracks = set()
     randomized_tracks = []
     for playlist in config['RANDOMIZE_TRACKS_PLAYLISTS']:
         try:
-            tracks = get_playlist_track_locations(soup, playlist, lookup)
+            tracks = get_playlist_track_locations(soup, playlist, seen_tracks)
         except LookupError as exc:
             logger.error(exc)
             continue
@@ -54,10 +55,11 @@ def randomize_tracks(config):
         random.shuffle(tracks)
         randomized_tracks.extend(tracks)
 
+    randomized_tracks = [lookup[x] for x in randomized_tracks]
     payload = [randomized_tracks, list(range(1, len(randomized_tracks) + 1))]
     with ThreadPoolExecutor(max_workers=os.cpu_count() * 4) as executor:
         _ = list(tqdm(executor.map(set_tag, *payload),
-                        total=len(tracks),
+                        total=len(randomized_tracks),
                         desc=f'Randomizing {len(randomized_tracks)} tracks'))
 
     wrap_playlists(soup, randomized_tracks)
@@ -68,27 +70,32 @@ def randomize_tracks(config):
         _file.write(soup.prettify('utf-8'))
 
 
-def get_playlist_track_locations(soup, _playlist, lookup):
-    """Finds playlist in 'XML_PATH' that matches '_playlist' and returns a dict
-    of the playlist node and track nodes.
+def get_playlist_track_locations(soup, _playlist, seen_tracks):
+    """Finds playlist in 'XML_PATH' that matches '_playlist' and returns a list
+    of the track nodes in that playlist that aren't in 'seen_tracks'.
 
     Args:
         soup (bs4.BeautifulSoup): parsed XML
         _playlist (str): name of playlist to randomize
-        lookup (dict): map of TrackIDs to 'Location'
+        seen_tracks (set): already seen TrackIDs
 
     Raises:
         LookupError: '_playlist' must exist
 
     Returns:
-        dict: playlist node and list of track nodes
+        list: TrackIDs
     """
     try:
         playlist = soup.find_all('NODE', {'Name': _playlist})[0]
     except IndexError:
         raise LookupError(f'{_playlist} not found') from LookupError
 
-    return [lookup[x['Key']] for x in playlist.children if str(x).strip()]
+    playlist_tracks = [track['Key'] for track in playlist.children
+                       if str(track).strip() and track['Key']
+                       not in seen_tracks]
+    seen_tracks.update(playlist_tracks)
+
+    return playlist_tracks
 
 
 def set_tag(track, index):
@@ -102,16 +109,17 @@ def set_tag(track, index):
 
 
 def wrap_playlists(soup, randomized_tracks):
-    """Creates a folder called 'AUTO_RANDOMIZE', inserts the generated playlist
-    structure into it, and then inserts 'AUTO_RANDOMIZE' into the root of the
+    """Creates a playlist called 'AUTO_RANDOMIZE', inserts the randomized
+    tracks into it, and then inserts 'AUTO_RANDOMIZE' into the root of the
     'Playlist' folder.
 
     Args:
         soup (bs4.BeautifulSoup): parsed XML
-        playlists (bs4.element.Tag): playlist structure
+        randomized_tracks (list): track nodes
     """
     playlists_root = soup.find_all('NODE', {'Name': 'ROOT', 'Type': '0'})[0]
-    new_playlist = soup.new_tag('NODE', Name='AUTO_RANDOMIZE', Type="1")
+    new_playlist = soup.new_tag('NODE', KeyType="0", Name='AUTO_RANDOMIZE',
+                                Type="1")
     for track in randomized_tracks:
-        new_playlist.appenkd(track)
+        new_playlist.append(soup.new_tag('TRACK', Key=track['TrackID']))
     playlists_root.insert(0, new_playlist)


### PR DESCRIPTION
* generate new `TrackNumber` values using the set of tracks across all playlists being randomized (no overwriting for tracks that exist in more than one of `RANDOMIZE_TRACKS_PLAYLISTS`)
* create a single `AUTO_RANDOMIZE` playlist rather than an `AUTO_RANDOMIZE` folder with a corollary randomized playlist for each in `RANDOMIZE_TRACKS_PLAYLISTS`
* fixed missing `KeyType=0` in newly generated playlist