### PR TITLE
better validation for --link_configs

### DIFF
--- a/src/djtools/dj_tools.py
+++ b/src/djtools/dj_tools.py
@@ -61,9 +61,9 @@ try:
     if config.get('LOG_LEVEL'):
         logger.setLevel(config['LOG_LEVEL'])
 except Exception as exc:
-    msg = f'Failed to load config: {exc}\n{format_exc()}'
+    msg = f'Failed to load config: {exc}'
     logger.critical(msg)
-    raise ValueError(msg) from Exception
+    raise ValueError(msg) from exc
 
 
 def main():

--- a/src/djtools/utils/config.py
+++ b/src/djtools/utils/config.py
@@ -252,13 +252,23 @@ def arg_parse():
             help='logger level')
     args = parser.parse_args()
 
-    if args.link_configs:
-        os.symlink(os.path.join(os.path.dirname(os.path.dirname(__file__)),
-                                'configs').replace(os.sep, '/'),
-                   args.link_configs,
-                   target_is_directory=True)
-
     if args.log_level:
         logger.setLevel(args.log_level)
+
+    if args.link_configs:
+        if os.path.exists(args.link_configs):
+            msg = f'{args.link_configs} must be a directory that does not ' \
+                  'already exist'
+            logger.error(msg)
+            raise ValueError(msg)
+        if not os.path.exists(os.path.dirname(args.link_configs)):
+            msg = f'{os.path.dirname(args.link_configs)} must be a ' \
+                  'directory that already exists'
+            logger.error(msg)
+            raise ValueError(msg)
+
+        package_root = os.path.dirname(os.path.dirname(__file__))
+        configs_dir = os.path.join(package_root, 'configs').replace(os.sep, '/')
+        os.symlink(configs_dir, args.link_configs, target_is_directory=True)
 
     return vars(args)

--- a/src/djtools/utils/helpers.py
+++ b/src/djtools/utils/helpers.py
@@ -27,5 +27,7 @@ def upload_log(config, log_file):
     now = datetime.now()
     one_day = timedelta(days=1)
     for _file in glob(f'{os.path.dirname(log_file)}/*'):
+        if os.path.basename(_file) == 'empty.txt':
+            continue
         if os.path.getctime(_file) < (now - one_day).timestamp():
             os.remove(_file)


### PR DESCRIPTION
* check that basename of `--link_configs` arg **does not** exist
* check that dirname of `--link_configs` arg **does** exist
* ignore `empty.txt` in logs dir when clearing out old files (prevent accidentally packaging `djtools` without `logs` directory)