### PR TITLE
djtools.utils.helpers.make_dirs

### DIFF
--- a/src/djtools/utils/helpers.py
+++ b/src/djtools/utils/helpers.py
@@ -31,3 +31,18 @@ def upload_log(config, log_file):
             continue
         if os.path.getctime(_file) < (now - one_day).timestamp():
             os.remove(_file)
+
+
+def make_dirs(path):
+    if os.name == 'nt':
+        cwd = os.getcwd()
+        path_parts = path.split(os.path.sep)
+        root = path_parts[0]
+        path_parts = path_parts[1:]
+        os.chdir(root)
+        for part in path_parts:
+            os.makedirs(part, exist_ok=True)
+            os.chdir(part)
+        os.chdir(cwd)
+    else:
+        os.makedirs(path, exist_ok=True)

--- a/src/djtools/utils/youtube_dl.py
+++ b/src/djtools/utils/youtube_dl.py
@@ -9,6 +9,8 @@ import re
 
 import youtube_dl as ytdl
 
+from djtools.utils.helpers import make_dirs
+
 
 logger = logging.getLogger(__name__)
 
@@ -28,18 +30,7 @@ def youtube_dl(config):
     dest_path = os.path.join(config['USB_PATH'], 'DJ Music', 'New Music',
                              '').replace(os.sep, '/')
     if not os.path.exists(dest_path):
-        if os.name == 'nt':
-            cwd = os.getcwd()
-            path_parts = dest_path.split(os.path.sep)
-            root = path_parts[0]
-            path_parts = path_parts[1:]
-            os.chdir(root)
-            for part in path_parts:
-                os.makedirs(part, exist_ok=True)
-                os.chdir(part)
-            os.chdir(cwd)
-        else:
-            os.makedirs(dest_path, exist_ok=True)
+        make_dirs(dest_path)
 
     ydl_opts = {
         'format': 'bestaudio/best',


### PR DESCRIPTION
Replaces redundant Windows `os.makedirs` workaround code with generalized function