### PR TITLE
Three fixes...

### DIFF
--- a/src/djtools/configs/rekordbox_playlists.json
+++ b/src/djtools/configs/rekordbox_playlists.json
@@ -7,15 +7,24 @@
             "Bass House & Techno",
             "Breaks ~ Techno",
             "((Jungle | Breaks) ~ Techno) | (Garage ~ Tech House)",
-            "(Jungle | Breaks & Techno) | (Garage ~ Tech House)"
+            "(Jungle | Breaks & Techno) | (Garage ~ Tech House)",
+            "Jazzy | Hardstyle",
+            "Wave ~ Trap | Uplifting",
+            "Tech House ~ Minimal House"
         ]
     },
     "MyTagParser": {
         "name": "My Tags",
         "playlists": [
-            "Vocal",
-            "Synth",
-            "Bass Music"
+            {
+                "name": "_ignore",
+                "playlists": [
+                    "Vocal",
+                    "Wave"
+                ]
+            },
+            "Jazzy",
+            "Uplifiting"
         ]
     },
     "GenreTagParser": {

--- a/src/djtools/rekordbox/tag_parsers.py
+++ b/src/djtools/rekordbox/tag_parsers.py
@@ -162,11 +162,11 @@ class BooleanNode:
             if len(self.tracks):
                 tracks_A = self.tracks.pop(0)
             else:
-                tracks_A = set(tracks[self.tags.pop(0)].keys())
+                tracks_A = set(tracks.get(self.tags.pop(0), {}).keys())
             if len(self.tracks):
                 tracks_B = self.tracks.pop(0)
             else:
-                tracks_B = set(tracks[self.tags.pop(0)].keys())
+                tracks_B = set(tracks.get(self.tags.pop(0), {}).keys())
             self.tracks.insert(0, set(operator(tracks_A, tracks_B)))
         
         return next(iter(self.tracks), set())


### PR DESCRIPTION
* Union tags matching across parsers instead of overwriting
* Pass `playlist_remainder_type` config option for "Other" playlists
* Fail-safe when trying to combine tags that don't exist