### PR TITLE
Config fixup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,9 +52,11 @@ EXTRAS = {
 
 setup(
     name='dj_beatcloud',
-    version='2.4.0-beta.16',
-    description='DJ Tools is a library for managing a collection of MP3 ' \
-                'and Rekordbox XML files.',
+    version='2.4.0-beta.19',
+    description=(
+        'DJ Tools is a library for managing a collection of music and '
+        'Rekordbox XML files.'
+    ),
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     url='https://github.com/a-rich/DJ-tools',

--- a/src/djtools/configs/helpers.py
+++ b/src/djtools/configs/helpers.py
@@ -42,31 +42,26 @@ def arg_parse() -> argparse.Namespace:
     parser.add_argument(
         "--auto-playlist-default-limit",
         type=int,
-        default=50,
         help="Default number of tracks for a Spotify auto-playlist",
     )
     parser.add_argument(
         "--auto-playlist-default-period",
         type=str,
-        default="week",
         help="Default Subreddit time filter for a Spotify auto-playlist",
     )
     parser.add_argument(
         "--auto-playlist-default-type",
         type=str,
-        default="hot",
         help="Default Subreddit post filter for a Spotify auto-playlist",
     )
     parser.add_argument(
         "--auto-playlist-fuzz-ratio",
         type=int,
-        default=70,
         help="Minimum similarity to add track to an auto-playlist",
     )
     parser.add_argument(
         "--auto-playlist-post-limit",
         type=int,
-        default=100,
         help="Maximum Subreddit posts to query for each auto-playlist",
     )
     parser.add_argument(
@@ -85,7 +80,6 @@ def arg_parse() -> argparse.Namespace:
     parser.add_argument(
         "--aws-profile",
         type=str,
-        default="",
         help="AWS config profile",
     )
     parser.add_argument(
@@ -108,7 +102,6 @@ def arg_parse() -> argparse.Namespace:
     parser.add_argument(
         "--check-tracks-fuzz-ratio",
         type=int,
-        default=80,
         help=(
             "Minimum similarity to indicate overlap between Beatcloud and "
             "Spotify / local tracks"
@@ -135,7 +128,6 @@ def arg_parse() -> argparse.Namespace:
     parser.add_argument(
         "--copy-tracks-playlists-destination",
         type=str,
-        default="",
         help="Location to copy Rekordbox playlists' audio files to",
     )
     parser.add_argument(

--- a/src/djtools/rekordbox/playlist_builder.py
+++ b/src/djtools/rekordbox/playlist_builder.py
@@ -307,20 +307,15 @@ class PlaylistBuilder:
                 # NOTE: Special logic to distinguish between the general "Hip Hop"
                 # playlist (a.k.a. pure Hip Hop) and the "Hip Hop" playlist under
                 # the "Bass" folder (a.k.a. bass Hip Hop)
-                skip_add = False
-                if pure_hip_hop and \
-                        any(
-                            "r&b" not in x.lower() and "hip hop" not in x.lower()
-                            for x in tags
-                        ):
-                    skip_add = True
-                if bass_hip_hop and \
-                        all(
-                            "r&b" in x.lower() or "hip hop" in x.lower()
-                            for x in tags
-                        ):
-                    skip_add = True
-                if skip_add:
+                if (pure_hip_hop and any(
+                        "r&b" not in x.lower() and "hip hop" not in x.lower()
+                        for x in tags
+                    )
+                ) or (bass_hip_hop and all(
+                        "r&b" in x.lower() or "hip hop" in x.lower()
+                        for x in tags
+                    )
+                ):
                     continue
 
                 if track_id not in seen[seen_index]:

--- a/src/djtools/spotify/config.py
+++ b/src/djtools/spotify/config.py
@@ -24,7 +24,7 @@ class SubredditConfig(BaseModel):
     ] = "week"
     type: Literal [
         "controversial", "hot", "new", "rising", "top"
-    ]= "hot"
+    ] = "hot"
 
 
 class SpotifyConfig(BaseConfig):

--- a/src/djtools/spotify/helpers.py
+++ b/src/djtools/spotify/helpers.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 import yaml
 
 from djtools.configs.config import BaseConfig
-from djtools.spotify.config import SpotifyConfig
+from djtools.spotify.config import SpotifyConfig, SubredditConfig
 
 
 logger = logging.getLogger(__name__)
@@ -23,13 +23,14 @@ logger = logging.getLogger(__name__)
 def build_new_playlist(
     spotify: spotipy.Spotify,
     username: str,
-    subreddit: Dict[str, Union[str, int]],
+    subreddit: str,
     new_tracks: List[Tuple[str]],
 ) -> Dict[str, Any]:
     """Creates a new playlist from a list of track IDs / URLs.
 
     Args:
         spotify: Spotify client.
+        username: Spotify username.
         subreddit: Subreddit name to filter.
         new_tracks: List of Spotify track ("id", "name") tuples.
 
@@ -230,7 +231,7 @@ def get_spotify_client(
 async def get_subreddit_posts(
     spotify: spotipy.Spotify,
     reddit: praw.Reddit,
-    subreddit: Dict[str, Union[str, int]],
+    subreddit: SubredditConfig,
     config: SpotifyConfig,
     praw_cache: Dict[str, bool],
 ) -> Tuple[List[Tuple[str]], Dict[str, Union[str, int]]]:
@@ -241,35 +242,27 @@ async def get_subreddit_posts(
     Args:
         spotify: Spotify client.
         reddit: Reddit client.
-        subreddit: "name", "type", "period", and "limit".
+        subreddit: SubredditConfig object.
         config: Configuration object.
         praw_cache: Cached praw submissions.
-    
-    Raises:
-        AttributeError: "type" must match a method of the "Subreddit" class.
 
     Returns:
-        List of Spotify track ("id", "name") tuples and subreddit config dict.
+        List of Spotify track ("id", "name") tuples and SubredditConfig.
     """
     # TODO(a-rich): Find another way to resolve cicular import.
     from djtools.utils.helpers import catch, raise_
 
     sub_limit = config.AUTO_PLAYLIST_POST_LIMIT
-    sub = await reddit.subreddit(subreddit["name"])
-    try:
-        func = getattr(sub, subreddit["type"])
-    except AttributeError:
-        raise AttributeError(
-            f'Method "{subreddit["type"]}" does not exist in "Subreddit" class'
-        ) from AttributeError
-    if subreddit["type"] == "top":
+    sub = await reddit.subreddit(subreddit.name)
+    func = getattr(sub, subreddit.type)
+    if subreddit.type == "top":
         subs = [
             x async for x in catch(
                 func,
                 handle=lambda exc: raise_(exc)
                     if isinstance(exc, TypeError) else logger.info(exc),
                 limit=sub_limit,
-                time_filter=subreddit["period"],
+                time_filter=subreddit.period,
             )
         ]
     else:
@@ -280,10 +273,7 @@ async def get_subreddit_posts(
                 limit=sub_limit,
             )
         ]
-    msg = (
-        f'Filtering {len(subs)} "r/{subreddit["name"]}" {subreddit["type"]} '
-        "posts"
-    )
+    msg = f'Filtering {len(subs)} "r/{subreddit.name}" {subreddit.type} posts'
     logger.info(msg)
     submissions = []
     for submission in tqdm(subs, desc=msg):
@@ -295,7 +285,7 @@ async def get_subreddit_posts(
     if len(submissions):
         msg = (
             f"Searching Spotify for {len(submissions)} new submission(s) from "
-            f'"r/{subreddit["name"]}"'
+            f'"r/{subreddit.name}"'
         )
         logger.info(msg)
         payload = [
@@ -314,10 +304,10 @@ async def get_subreddit_posts(
         new_tracks = [track for track in new_tracks if track]
         logger.info(
             f"Got {len(new_tracks)} Spotify track(s) from new "
-            f'"r/{subreddit["name"]}" posts'
+            f'"r/{subreddit.name}" posts'
         )
     else:
-        logger.info(f'No new submissions from "r/{subreddit["name"]}"')
+        logger.info(f'No new submissions from "r/{subreddit.name}"')
 
     return new_tracks, subreddit
 

--- a/src/djtools/spotify/playlist_builder.py
+++ b/src/djtools/spotify/playlist_builder.py
@@ -49,20 +49,7 @@ async def async_update_auto_playlists(config: SpotifyConfig):
 
     Args:
         config: Configuration object.
-    
-    Raises:
-        ValueError: Subreddit configs must include a name.
     """
-    required_subreddit_keys = {"type", "period", "limit"}
-    for subreddit in config.AUTO_PLAYLIST_SUBREDDITS:
-        if "name" not in subreddit:
-            raise ValueError("Subreddit configs must include a name.")
-        for key in required_subreddit_keys:
-            subreddit[key] = subreddit.get(
-                key,
-                getattr(config, f"AUTO_PLAYLIST_DEFAULT_{key.upper()}")
-            )
-
     spotify = get_spotify_client(config)
     reddit = get_reddit_client(config)
     playlist_ids = get_playlist_ids()
@@ -91,12 +78,12 @@ async def async_update_auto_playlists(config: SpotifyConfig):
     for task in asyncio.as_completed(tasks):
         tracks, subreddit = await task
         playlist_ids = populate_playlist(
-            playlist_name=subreddit["name"],
+            playlist_name=subreddit.name,
             playlist_ids=playlist_ids,
             spotify_username=config.SPOTIFY_USERNAME,
             spotify=spotify,
             tracks=tracks,
-            playlist_limit=subreddit["limit"],
+            playlist_limit=subreddit.limit,
             verbosity=config.VERBOSITY,
         )
     

--- a/src/djtools/spotify/test_helpers.py
+++ b/src/djtools/spotify/test_helpers.py
@@ -5,6 +5,7 @@ import asyncpraw
 import pytest
 import spotipy
 
+from djtools.spotify.config import SubredditConfig
 from djtools.spotify.helpers import (
     build_new_playlist,
     filter_results,
@@ -312,9 +313,7 @@ async def test_get_subreddit_posts(
     caplog,
 ):
     caplog.set_level("INFO")
-    subreddit = {
-        "name": "techno", "type": subreddit_type, "period": "week", "limit": 50
-    }
+    subreddit = SubredditConfig(name="techno", type=subreddit_type)
     praw_cache = {}
     mock_praw_submission.id = "test_id"
     mock_process.return_value = "track - artist"
@@ -342,33 +341,6 @@ async def test_get_subreddit_posts(
         assert caplog.records[2].message == (
             'Got 1 Spotify track(s) from new "r/techno" posts'
         )
-
-
-@pytest.mark.asyncio
-@mock.patch("djtools.spotify.helpers.praw.Reddit")
-@mock.patch("djtools.spotify.helpers.get_spotify_client")
-async def test_get_subreddit_posts_handle_bad_subreddit_method(
-    mock_spotify, mock_praw, test_config
-):
-    subreddit_type = "not-a-method"
-    subreddit = {
-        "name": "techno", "type": subreddit_type, "period": "week", "limit": 50
-    }
-    praw_cache = {}
-    with mock.patch(
-        "djtools.spotify.helpers.praw.Reddit.subreddit",
-        new=mock.AsyncMock(side_effect=lambda *args: None),
-    ):
-        with pytest.raises(
-            AttributeError,
-            match=(
-                f'Method "{subreddit_type}" does not exist in "Subreddit" '
-                "class"
-            ),
-        ):
-            await get_subreddit_posts(
-                mock_spotify, mock_praw, subreddit, test_config, praw_cache
-            )
 
 
 @pytest.mark.parametrize(

--- a/src/djtools/spotify/test_playlist_builder.py
+++ b/src/djtools/spotify/test_playlist_builder.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pyperclip
 import pytest
 
+from djtools.spotify.config import SubredditConfig
 from djtools.spotify.playlist_builder import (
     async_update_auto_playlists,
     playlist_from_upload,
@@ -19,8 +20,7 @@ pytest_plugins = [
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "playlist_subreddits",
-    [[], [{"name": "jungle", "type": "hot", "period": "week", "limit": 50}]],
+    "playlist_subreddits", [[], [SubredditConfig(name="jungle")]],
 )
 @pytest.mark.parametrize("got_playlist_ids", [True, False])
 @pytest.mark.parametrize("got_tracks", [True, False])
@@ -44,9 +44,7 @@ pytest_plugins = [
 @mock.patch(
     "djtools.spotify.playlist_builder.get_subreddit_posts",
     return_value=[
-        [("track-id", "track name")],
-        {"name": "jungle", "type": "hot", "period": "week", "limit": 50},
-    ],
+        [("track-id", "track name")], SubredditConfig(name="jungle")],
 )
 @mock.patch("djtools.spotify.playlist_builder.get_spotify_client")
 async def test_async_update_auto_playlists(
@@ -72,19 +70,6 @@ async def test_async_update_auto_playlists(
             files=["spotify_playlists.yaml", ".praw.cache"],
             content='{"jungle": "some-id"}' if got_playlist_ids else "{}",
         ).open
-    ):
-        await async_update_auto_playlists(test_config)
-
-
-@pytest.mark.asyncio
-async def test_async_update_auto_playlists_missing_subreddit_name(
-    test_config,
-):
-    test_config.AUTO_PLAYLIST_SUBREDDITS = [
-        {"type": "hot", "period": "week", "limit": 50}
-    ]
-    with pytest.raises(
-        ValueError, match="Subreddit configs must include a name."
     ):
         await async_update_auto_playlists(test_config)
 

--- a/src/djtools/sync/helpers.py
+++ b/src/djtools/sync/helpers.py
@@ -140,8 +140,11 @@ def run_sync(_cmd: str) -> str:
                         )[-1]
                     )
                 else:
-                    print(f"{line.strip()}                                  " \
-                          "                        ", end="\r", flush=True)
+                    print(
+                        f"{line.strip()}                                  "
+                        "                        ",
+                        end="\r", flush=True
+                    )
 
             proc.stdout.close()
             return_code = proc.wait()


### PR DESCRIPTION
Why?
To ensure consistency in the library and minimize error handling at the point of execution. Fix a bugs related to referencing the old subreddit configuration object.

What?

Remove all uses of "\" for line continuation. Remove unnecessary error handling in `get_subreddit_posts`. Remove erroneous validation in `async_update_auto_playlists` and erroneous referencing of dictionary members after switching to the `SubredditConfig` Pydantic model. Simplify special hip hop playlist builder logic. Remove default `ArgumentParser` options.