### PR TITLE
Ascii playlist stats

### DIFF
--- a/djtools/rekordbox/helpers.py
+++ b/djtools/rekordbox/helpers.py
@@ -1,4 +1,5 @@
 """This module contains helpers for the rekordbox package."""
+from operator import itemgetter
 from pathlib import Path
 import re
 import shutil
@@ -137,6 +138,52 @@ def get_playlist_tracks(
     seen_tracks.update(playlist_tracks)
 
     return playlist_tracks
+
+
+def print_data(data: Dict[str, int]):
+    """Prints an ASCII histogram of tag data.
+
+    Args:
+        data: Tag names to tag counts.
+    """
+    scaled_data = scale_data(data)
+    row_width = 0
+    width_pad = 1
+    row = max(scaled_data.items(), key=itemgetter(1))[1]
+    output = ""
+    while row > 0:
+        output += "|"
+        for key in data:
+            key_width = len(key)
+            key_center = round(key_width / 2)
+            output += f"{' ' * (width_pad + key_center)}"
+            output += f"{'*' if row <= scaled_data[key] else ' '}"
+            output += f"{' ' * (width_pad + key_center)}"
+        if not row_width:
+            row_width = len(output)
+        output += "\n"
+        row -= 1
+    output += "-" * row_width + "\n "
+    for key in data:
+        output += f"{' ' * width_pad}{key}{' ' * (width_pad + 1)}"
+    print(output)
+
+
+def scale_data(
+    data: Dict[str, int], maximum: Optional[int] = 25
+) -> Dict[str, int]:
+    """Scales range of data values with an upper bound.
+
+    Args:
+        data: Tag names to tag counts.
+        maximum: Upper bound for rescaled data.
+
+    Returns:
+        Rescaled dictionary of tag names and tag counts.
+    """
+    data_max = max(data.items(), key=itemgetter(1))[1]
+
+    return {k: round((v / data_max) * maximum) for k, v in data.items()}
 
 
 def set_track_number(track: str, index: int):

--- a/djtools/rekordbox/test_helpers.py
+++ b/djtools/rekordbox/test_helpers.py
@@ -10,6 +10,8 @@ from djtools.rekordbox.helpers import (
     BooleanNode,
     copy_file,
     get_playlist_tracks,
+    print_data,
+    scale_data,
     set_track_number,
 )
 
@@ -100,6 +102,72 @@ def test_get_playlist_tracks_no_playlist(xml):
     seen_tracks = set()
     with pytest.raises(LookupError, match=f"{playlist} not found"):
         get_playlist_tracks(xml, playlist, seen_tracks)
+
+
+def test_print_data(capsys):
+    """Test for the print_data function."""
+    data = {
+        "Aggro": 30,
+        "Bounce": 2,
+        "Chill": 1,
+        "Dark": 19,
+        "Melodic": 9,
+        "Rave": 13,
+    }
+    expected = (
+        "|   *                                            \n" +
+        "|   *                                            \n" +
+        "|   *                                            \n" +
+        "|   *                                            \n" +
+        "|   *                                            \n" +
+        "|   *                                            \n" +
+        "|   *                                            \n" +
+        "|   *                                            \n" +
+        "|   *                                            \n" +
+        "|   *                      *                     \n" +
+        "|   *                      *                     \n" +
+        "|   *                      *                     \n" +
+        "|   *                      *                     \n" +
+        "|   *                      *                     \n" +
+        "|   *                      *                 *   \n" +
+        "|   *                      *                 *   \n" +
+        "|   *                      *                 *   \n" +
+        "|   *                      *        *        *   \n" +
+        "|   *                      *        *        *   \n" +
+        "|   *                      *        *        *   \n" +
+        "|   *                      *        *        *   \n" +
+        "|   *                      *        *        *   \n" +
+        "|   *                      *        *        *   \n" +
+        "|   *       *              *        *        *   \n" +
+        "|   *       *       *      *        *        *   \n" +
+        "-------------------------------------------------\n" +
+        "  Aggro   Bounce   Chill   Dark   Melodic   Rave  \n"
+    )
+    print_data(data)
+    cap = capsys.readouterr()
+    assert cap.out == expected
+
+
+def test_scale_output():
+    """Test for the scale_output function."""
+    data = {
+        "Aggro": 30,
+        "Bounce": 2,
+        "Chill": 1,
+        "Dark": 19,
+        "Melodic": 9,
+        "Rave": 13,
+    }
+    expected = {
+        "Aggro": 25,
+        "Bounce": 2,
+        "Chill": 1,
+        "Dark": 16,
+        "Melodic": 8,
+        "Rave": 11,
+    }
+    scaled_data = scale_data(data, maximum=25)
+    assert scaled_data == expected
 
 
 @pytest.mark.parametrize("index", [0, 5, 9])


### PR DESCRIPTION
    feat(playlist_buildeR): print ASCII histograms of tag statistics
    
    Why?
    To quickly iterate on the proper Combiner playlist expressions, it would
    be helpful if the CLI immediately output useful information to help
    guide users in the right direction.
    
    What?
    Print simple ASCII tables for each TagParser implementation for each
    playlist in the set of Combiner playlists generated in the run. Tables
    show the frequency of each tag's apperance in each playlist. Tag
    frequencies are scaled to a maximum value to constrain table heights.
    
    TODO: Investigate vertical X-axis labels to constrain histogram width.
    Investigate splitting histograms into chunks when there is a large
    number of X-axis labels.