### PR TITLE
feat(playlists): verbosity and empty tag filter

### DIFF
--- a/djtools/rekordbox/helpers.py
+++ b/djtools/rekordbox/helpers.py
@@ -1,4 +1,5 @@
 """This module contains helpers for the rekordbox package."""
+from collections import defaultdict
 from operator import itemgetter
 from pathlib import Path
 import re
@@ -140,12 +141,41 @@ def get_playlist_tracks(
     return playlist_tracks
 
 
+def print_playlists_tag_statistics(
+    playlist_tracks: Dict[str, Set[str]],
+    track_lookup: Dict[str, Set[str]],
+    parser_tracks: Dict[str, Dict[str, List[Tuple[str, List[str]]]]],
+) -> None:
+    """Prints tag statistics for Combiner playlists.
+
+    Statistics are split out by Combiner playlist and then by TagParser type.
+
+    Args:
+        playlist_tracks: Combiner playlists mapped to track IDs.
+        track_lookup: Track IDs mapped to set of tags.
+        parser_tracks: Parser type mapped to tags mapped to list of
+            (track ID, tag list) tuples.
+    """
+    for playlist, _tracks in playlist_tracks.items():
+        if not _tracks:
+            continue
+        print(f"\n{playlist} tag statistics:")
+        playlist_tags = defaultdict(int)
+        for track in _tracks:
+            for tag in track_lookup[track]:
+                playlist_tags[tag] += 1
+        for parser, parser_tags in parser_tracks.items():
+            print(f"\n{parser}:")
+            print_data({k: playlist_tags[k] for k in parser_tags})
+
+
 def print_data(data: Dict[str, int]):
     """Prints an ASCII histogram of tag data.
 
     Args:
         data: Tag names to tag counts.
     """
+    data = {k: v for k, v in data.items() if v}
     scaled_data = scale_data(data)
     row_width = 0
     width_pad = 1

--- a/djtools/rekordbox/test_playlist_builder.py
+++ b/djtools/rekordbox/test_playlist_builder.py
@@ -13,6 +13,7 @@ from djtools.rekordbox.playlist_builder import (
 def test_build_playlists(test_config, test_xml):
     """Test for the build_playlists function."""
     test_config.XML_PATH = Path(test_xml)
+    test_config.VERBOSITY = 1
     build_playlists(test_config)
 
 

--- a/djtools/version.py
+++ b/djtools/version.py
@@ -1,2 +1,2 @@
 """This module is the single source for this package's version."""
-__version__ = "2.5.1-b4"
+__version__ = "2.5.1-b5"


### PR DESCRIPTION
Why?
Printing playlist tag statistics can be quite verbose; users should have the option to suppress it by omitting `--verbosity`. Output is made more verbose than necessary by printing columns for empty tags.

What?
Move the playlist tag statistic printing logic into a helper function. Only call that function if `--verbosity` is set to a non-zero value. Pre-filter the tag data for zero values.