### PR TITLE
feat(sync): robustify collection syncing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
       uses: programmingwithalex/pytester-cov@main
       with:
         pytest-root-dir: 'djtools/'
-        cov-omit-list: 'djtools/__main__.py, djtools/**/test_*'
+        cov-omit-list: 'djtools/__main__.py'
         cov-threshold-single: ${{ env.COVERAGE_SINGLE }}
         cov-threshold-total: ${{ env.COVERAGE_TOTAL }}
 

--- a/djtools/sync/sync_operations.py
+++ b/djtools/sync/sync_operations.py
@@ -77,15 +77,16 @@ def download_collection(config: BaseConfig):
     """
     logger.info(f"Downloading {config.IMPORT_USER}'s collection...")
     collection_dir = config.COLLECTION_PATH.parent
-    collection_dir.mkdir(parents=True, exist_ok=True)
     _file = (
         Path(collection_dir) /
         f'{config.IMPORT_USER}_{config.COLLECTION_PATH.name}'
     )
     cmd = (
         "aws s3 cp s3://dj.beatcloud.com/dj/collections/"
-        f'{config.IMPORT_USER}/collection {_file}'
+        f'{config.IMPORT_USER}/{config.PLATFORM}_collection {_file}'
     )
+    if config.COLLECTION_PATH.is_dir():
+        cmd += " --recursive"
     logger.info(cmd)
     with Popen(cmd, shell=True) as proc:
         proc.wait()
@@ -134,8 +135,13 @@ def upload_collection(config: BaseConfig):
         config: Configuration object.
     """
     logger.info(f"Uploading {config.USER}'s collection...")
-    dst = f"s3://dj.beatcloud.com/dj/collections/{config.USER}/collection"
+    dst = (
+        f"s3://dj.beatcloud.com/dj/collections/{config.USER}/"
+        f"{config.PLATFORM}_collection"
+    )
     cmd = f"aws s3 cp {config.COLLECTION_PATH} {dst}"
+    if config.COLLECTION_PATH.is_dir():
+        cmd += " --recursive"
     logger.info(cmd)
     with Popen(cmd, shell=True) as proc:
         proc.wait()

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(
     url='https://github.com/a-rich/DJ-tools',
     author='Alex Richards',
     author_email='alex.richards006@gmail.com',
-    license='GNU GPLv3',
     packages=[
         "djtools",
         "djtools.configs",

--- a/testing/sync/test_helpers.py
+++ b/testing/sync/test_helpers.py
@@ -177,8 +177,8 @@ def test_run_sync_handles_return_code(mock_popen, tmpdir, caplog):
     assert caplog.records[0].message == msg
 
 
-@mock.patch("subprocess.Popen.wait", mock.Mock())
-def test_upload_log(tmpdir, config):
+@mock.patch("djtools.sync.helpers.Popen")
+def test_upload_log(mock_popen, tmpdir, config):
     """Test for the upload_log function."""
     config.AWS_PROFILE = "DJ"
     now = datetime.now()
@@ -196,6 +196,8 @@ def test_upload_log(tmpdir, config):
             _file.write("stuff")
         if filename != test_log:
             os.utime(file_path, (ctime, ctime))
+    process = mock_popen.return_value.__enter__.return_value
+    process.wait.return_value = 0
     upload_log(config, Path(tmpdir) / test_log)
     assert len(list(Path(tmpdir).iterdir())) == len(filenames) - 1
 

--- a/testing/sync/test_sync_operations.py
+++ b/testing/sync/test_sync_operations.py
@@ -53,9 +53,17 @@ def test_download_music(playlist_name, config, tmpdir, caplog):
     assert Path(caplog.records[4].message).name == "file.mp3"
 
 
+@pytest.mark.parametrize("collection_is_dir", [True, False])
 @mock.patch("djtools.sync.sync_operations.rewrite_track_paths")
-@mock.patch("subprocess.Popen.wait", mock.Mock())
-def test_download_collection(mock_rewrite_track_paths, config, rekordbox_xml, caplog):
+@mock.patch("djtools.sync.sync_operations.Popen")
+def test_download_collection(
+    mock_popen,
+    mock_rewrite_track_paths,
+    collection_is_dir,
+    config,
+    rekordbox_xml,
+    caplog,
+):
     """Test for the download_collection function."""
     caplog.set_level("INFO")
     test_user = "test_user"
@@ -65,17 +73,27 @@ def test_download_collection(mock_rewrite_track_paths, config, rekordbox_xml, ca
     config.USER = test_user
     config.IMPORT_USER = other_user
     config.COLLECTION_PATH = rekordbox_xml
-    download_collection(config)
+    config.PLATFORM = "rekordbox"
+    process = mock_popen.return_value.__enter__.return_value
+    process.wait.return_value = 0
+    with mock.patch(
+        "djtools.sync.sync_operations.Path.is_dir",
+        lambda path: collection_is_dir,
+    ):
+        download_collection(config)
     cmd = [
         "aws",
         "s3",
         "cp",
-        f's3://dj.beatcloud.com/dj/collections/{other_user}/collection',
+        f"s3://dj.beatcloud.com/dj/collections/{other_user}/"
+        f"{config.PLATFORM}_collection",
         # NOTE(a-rich): since we could be passing a `rekordbox_xml` formatted
         # as a WindowsPath, the comparison needs to be made with `str(new_xml)`
         # (rather than `new_xml.as_posix()`).
         str(new_xml),
     ]
+    if collection_is_dir:
+        cmd.append("--recursive")
     assert caplog.records[0].message == (
         f"Downloading {config.IMPORT_USER}'s collection..."
     )
@@ -121,18 +139,31 @@ def test_upload_music(
         )
 
 
-@mock.patch("subprocess.Popen.wait", mock.Mock())
-def test_upload_collection(config, rekordbox_xml, caplog):
+@pytest.mark.parametrize("collection_is_dir", [True, False])
+@mock.patch("djtools.sync.sync_operations.Popen")
+def test_upload_collection(
+    mock_popen, collection_is_dir, config, rekordbox_xml, caplog
+):
     """Test for the upload_collection function."""
     caplog.set_level("INFO")
     user = "user"
     config.USER =user
     config.COLLECTION_PATH = rekordbox_xml
+    config.PLATFORM = "rekordbox"
     cmd = (
-        f"aws s3 cp {rekordbox_xml} "
-        f"s3://dj.beatcloud.com/dj/collections/{user}/collection"
+        f"aws s3 cp {config.COLLECTION_PATH} "
+        f"s3://dj.beatcloud.com/dj/collections/{user}/"
+        f"{config.PLATFORM}_collection"
     )
-    upload_collection(config)
+    if collection_is_dir:
+        cmd += " --recursive"
+    process = mock_popen.return_value.__enter__.return_value
+    process.wait.return_value = 0
+    with mock.patch(
+        "djtools.sync.sync_operations.Path.is_dir",
+        lambda path: collection_is_dir,
+    ):
+        upload_collection(config)
     assert caplog.records[0].message == (
         f"Uploading {user}'s collection..."
     )


### PR DESCRIPTION
Why?
Neither syncing collections from multiple platforms nor syncing directory-type collections was supported.

What?
Prefix the name of the collection being synced with the PLATFORM option. Check if the local COLLECTION_PATH is a directory and append `--recursive` to the sequence of args used in the `aws` command accordingly.