### PR TITLE
fix: More elegant music sync

### DIFF
--- a/djtools/sync/sync_operations.py
+++ b/djtools/sync/sync_operations.py
@@ -44,12 +44,12 @@ def download_music(config: BaseConfig, beatcloud_tracks: Optional[List[str]] = N
         ]
         config.DOWNLOAD_EXCLUDE_DIRS = []
 
+    logger.info("Downloading track collection...")
     dest = Path(config.USB_PATH) / "DJ Music"
     glob_path = (Path("**") / "*.*").as_posix()
     old = {str(p) for p in dest.rglob(glob_path)}
-    logger.info(f"Found {len(old)} files")
+    logger.info(f"Found {len(old)} files at {config.USB_PATH}")
 
-    logger.info("Downloading track collection...")
     dest.mkdir(parents=True, exist_ok=True)
     cmd = [
         "aws", "s3", "sync", "s3://dj.beatcloud.com/dj/music/", dest.as_posix()
@@ -75,22 +75,24 @@ def download_collection(config: BaseConfig):
     Args:
         config: Configuration object.
     """
-    logger.info(f"Downloading {config.IMPORT_USER}'s collection...")
+    logger.info(
+        f"Downloading {config.IMPORT_USER}'s {config.PLATFORM} collection..."
+    )
     collection_dir = config.COLLECTION_PATH.parent
     collection_dir.mkdir(parents=True, exist_ok=True)
-    _file = (
+    src = (
+        f"s3://dj.beatcloud.com/dj/collections/{config.IMPORT_USER}/collection"
+    )
+    dst = (
         Path(collection_dir) /
         f'{config.IMPORT_USER}_{config.COLLECTION_PATH.name}'
     )
-    cmd = (
-        "aws s3 cp s3://dj.beatcloud.com/dj/collections/"
-        f'{config.IMPORT_USER}/collection {_file}'
-    )
-    logger.info(cmd)
-    with Popen(cmd, shell=True) as proc:
+    cmd = ["aws", "s3", "cp", src, dst.as_posix()]
+    logger.info(" ".join(cmd))
+    with Popen(cmd) as proc:
         proc.wait()
     if config.USER != config.IMPORT_USER:
-        rewrite_track_paths(config, _file)
+        rewrite_track_paths(config, dst)
 
 
 def upload_music(config: BaseConfig):
@@ -133,9 +135,11 @@ def upload_collection(config: BaseConfig):
     Args:
         config: Configuration object.
     """
-    logger.info(f"Uploading {config.USER}'s collection...")
+    logger.info(
+        f"Uploading {config.USER}'s {config.PLATFORM} collection..."
+    )
     dst = f"s3://dj.beatcloud.com/dj/collections/{config.USER}/collection"
-    cmd = f"aws s3 cp {config.COLLECTION_PATH} {dst}"
-    logger.info(cmd)
-    with Popen(cmd, shell=True) as proc:
+    cmd = ["aws", "s3", "cp", config.COLLECTION_PATH.as_posix(), dst]
+    logger.info(" ".join(cmd))
+    with Popen(cmd) as proc:
         proc.wait()

--- a/djtools/utils/helpers.py
+++ b/djtools/utils/helpers.py
@@ -171,8 +171,8 @@ def get_beatcloud_tracks() -> List[str]:
     Returns:
         Beatcloud track titles and artist names.
     """
-    cmd = "aws s3 ls --recursive s3://dj.beatcloud.com/dj/music/"
-    output = check_output(cmd, shell=True).decode("utf-8").split("\n")
+    cmd = ["aws", "s3", "ls", "--recursive", "s3://dj.beatcloud.com/dj/music/"]
+    output = check_output(cmd).decode("utf-8").split("\n")
     tracks = [Path(track) for track in output if track]
     logger.info(f"Got {len(tracks)} tracks from the beatcloud")
 

--- a/testing/sync/test_helpers.py
+++ b/testing/sync/test_helpers.py
@@ -130,11 +130,11 @@ def test_run_sync(mock_popen, tmpdir):
     # been created. The WAR is to initialize a `NamedTemporaryFile` with the
     # `delete` argument set to `False` and explicitly `.close()` the object
     # before calling `open()` on it.
-    with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp_file:
-        tmp_file.write(sync_output)
+    with tempfile.NamedTemporaryFile(mode="wb", delete=False) as tmp_file:
+        tmp_file.write(bytes(sync_output.encode("utf-8")))
         tmp_file.seek(0)
         tmp_file.close()
-        with open(tmp_file.name, encoding="utf-8") as tmp_file:
+        with open(tmp_file.name, mode="rb") as tmp_file:
             process = mock_popen.return_value.__enter__.return_value
             process.stdout = tmp_file
             process.wait.return_value = 0
@@ -160,11 +160,11 @@ def test_run_sync_handles_return_code(mock_popen, tmpdir, caplog):
         Path(tmpdir).as_posix(),
         "s3://dj.beatcloud.com/dj/music/",
     ]
-    with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp_file:
-        tmp_file.write("")
+    with tempfile.NamedTemporaryFile(mode="wb", delete=False) as tmp_file:
+        tmp_file.write(bytes("".encode("utf-8")))
         tmp_file.seek(0)
         tmp_file.close()
-        with open(tmp_file.name, encoding="utf-8") as tmp_file:
+        with open(tmp_file.name, mode="rb") as tmp_file:
             process = mock_popen.return_value.__enter__.return_value
             process.stdout = tmp_file
             process.wait.return_value = 1

--- a/testing/sync/test_sync_operations.py
+++ b/testing/sync/test_sync_operations.py
@@ -46,8 +46,8 @@ def test_download_music(playlist_name, config, tmpdir, caplog):
     ) as mock_run_sync:
         download_music(config)
         mock_run_sync.assert_called_with(cmd)
-    assert caplog.records[0].message == "Found 0 files"
-    assert caplog.records[1].message == "Downloading track collection..."
+    assert caplog.records[0].message == "Downloading track collection..."
+    assert caplog.records[1].message == f"Found 0 files at {config.USB_PATH}"
     assert caplog.records[2].message == " ".join(cmd)
     assert caplog.records[3].message == "Found 1 new files"
     assert Path(caplog.records[4].message).name == "file.mp3"
@@ -65,6 +65,7 @@ def test_download_collection(mock_rewrite_track_paths, config, rekordbox_xml, ca
     config.USER = test_user
     config.IMPORT_USER = other_user
     config.COLLECTION_PATH = rekordbox_xml
+    config.PLATFORM = "rekordbox"
     download_collection(config)
     cmd = [
         "aws",
@@ -77,7 +78,7 @@ def test_download_collection(mock_rewrite_track_paths, config, rekordbox_xml, ca
         str(new_xml),
     ]
     assert caplog.records[0].message == (
-        f"Downloading {config.IMPORT_USER}'s collection..."
+        f"Downloading {config.IMPORT_USER}'s {config.PLATFORM} collection..."
     )
     assert caplog.records[1].message == " ".join(cmd)
     mock_rewrite_track_paths.assert_called_once()
@@ -128,12 +129,13 @@ def test_upload_collection(config, rekordbox_xml, caplog):
     user = "user"
     config.USER =user
     config.COLLECTION_PATH = rekordbox_xml
+    config.PLATFORM = "rekordbox"
     cmd = (
         f"aws s3 cp {rekordbox_xml} "
         f"s3://dj.beatcloud.com/dj/collections/{user}/collection"
     )
     upload_collection(config)
     assert caplog.records[0].message == (
-        f"Uploading {user}'s collection..."
+        f"Uploading {user}'s {config.PLATFORM} collection..."
     )
     assert caplog.records[1].message == cmd


### PR DESCRIPTION
Why?
The carriage return prints made by `awscli` which contain information about the amount of data and number of files transferred was getting lost due to the use of `readline()` which splits on "\n" characters.

What?
Read stdout one character at a time so the carriage return data can be displayed.

Also remove the usage of `shell=True` from all `Popen` calls.