### PR TITLE
script: remove tags and populate fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ Please see the [docs](https://a-rich.github.io/DJ-Tools/) for tutorials, how-to 
 
 # Release Plan
 * 2.6.1
+    - [x] Script for removing situation tags and resolving album, label, and year for tracks
+    - [x] Allow `build_config` to accept an override for the path to `config.yaml`
+    - [x] Fix missing typehints for the `NonEmptyListElementAction` class
+    - [ ] [Make PlaylistFilter implementations configurable](https://github.com/a-rich/DJ-Tools/issues/120)
+    - [ ] [Make MinimalDeepTechFilter more robust to the relative position of House and Techno tags](https://github.com/a-rich/DJ-Tools/issues/122)
     - [ ] [Stability issues with requests to the search endpoint of the Spotify API](https://github.com/a-rich/DJ-Tools/issues/58)
     - [ ] [Make Spotify API calls asynchronous](https://github.com/a-rich/DJ-Tools/issues/38)
 * 2.7.0

--- a/djtools/configs/helpers.py
+++ b/djtools/configs/helpers.py
@@ -7,7 +7,7 @@ import json
 import logging
 from pathlib import Path
 import sys
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import yaml
 
@@ -39,7 +39,13 @@ class NonEmptyListElementAction(Action):
     having to first make an edit to their config.yaml (because the
     include/exclude options are mutually exclusive).
     """
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(
+        self,
+        parser: ArgumentParser,
+        namespace: Namespace,
+        values: List[str],
+        option_string: Optional[str] = None,
+    ):
         """Filter list-type arguments for empty strings.
 
         Args:
@@ -500,11 +506,14 @@ def arg_parse() -> Namespace:
     return vars(args)
 
 
-def build_config() -> BaseConfig:
+def build_config(config_file: Optional[Path] = None) -> BaseConfig:
     """This function loads configurations for the library.
     
     Configurations are loaded from config.yaml. If command-line arguments are
     provided, these override the configuration options set in config.yaml.
+
+    Args:
+        config_file: Optional path to a config.yaml.
 
     Raises:
         RuntimeError: config.yaml must be a valid YAML.
@@ -513,8 +522,9 @@ def build_config() -> BaseConfig:
         Global configuration object.
     """
     # Load "config.yaml".
-    config_dir = Path(__file__).parent.parent / "configs"
-    config_file = config_dir / "config.yaml"
+    if not config_file:
+        config_dir = Path(__file__).parent.parent / "configs"
+        config_file = config_dir / "config.yaml"
     if config_file.exists():
         try:
             with open(config_file, mode="r", encoding="utf-8") as _file:

--- a/scripts/xml/remove_situation_tags_and_populate_album_year_label.py
+++ b/scripts/xml/remove_situation_tags_and_populate_album_year_label.py
@@ -1,0 +1,90 @@
+"""This module is a script for modifying a Collection.
+
+More specifically, it queries Spotify for each track and attempts to resolve
+the year, album, and label. In addition, it removes "situation" tags
+{"Opener", "Build", "Peak Time"} from the Comments field. This is done because
+I'm now repurposing the "Rating" field to convey the energy level of tracks.
+"""
+from argparse import ArgumentParser
+from concurrent.futures import as_completed, ThreadPoolExecutor
+from datetime import datetime
+from pathlib import Path
+import re
+
+from tqdm import tqdm
+
+from djtools.configs.helpers import build_config
+from djtools.collection.collections import RekordboxCollection
+from djtools.spotify.helpers import filter_results, get_spotify_client
+
+
+def thread(track):
+    """Threaded function.
+
+    Hits the Spotify API and tries to find a matching track. If found, resolve
+    the year, album, and label fields of the track. Then, if the track has
+    "My Tag" data in the Comments field, remove the "situation" tags.
+
+    Args:
+        track: A Track object.
+    """
+    # Search Spotify for the track.
+    title = getattr(track, "_Name")
+    artist = getattr(track, "_Artist")
+    query = f"track:{title} artist:{artist}"
+    results = spotify.search(q=query, type="track", limit=50)
+    match, _ = filter_results(spotify, results, threshold, title, artist)
+    if match:
+        result = spotify.album(match["album"]["id"])
+        album = result["name"]
+        label = result["label"]
+        for date_format in ["%Y-%m-%d", "%Y-%m", "%Y"]:
+            try:
+                date = datetime.strptime(result["release_date"], date_format)
+            except ValueError:
+                continue
+        year = str(date.year)
+        for attribute_name, attribute in [
+            ("album", album), ("label", label), ("year", year)
+        ]:
+            setattr(track, f"_{attribute_name.title()}", attribute)
+
+    # Remove "Situation" tags.
+    comments = getattr(track, "_Comments")
+    tags = re.search(tag_regex, comments)
+    if not tags:
+        return
+    comment_prefix = comments.split("/* ")[0].strip()
+    comment_suffix = comments.split(" */")[-1].strip()
+    new_tags = " / ".join(
+        [
+            tag.strip() for tag in tags.group().split("/")
+            if tag.strip() not in remove_tags
+        ]
+    )
+    if new_tags:
+        setattr(track, "_Comments", f'{comment_prefix} /* {new_tags} */ {comment_suffix}')
+    else:
+        setattr(track, "_Comments", f'{comment_prefix} {comment_suffix}')
+
+
+if __name__ == "__main__":
+    arg_parser = ArgumentParser()
+    arg_parser.add_argument("--config", help="Path to a config.yaml")
+    arg_parser.add_argument("--collection", help="Path to a collection")
+    args = arg_parser.parse_args()
+    config_path = Path(args.config)
+    collection = RekordboxCollection(path=Path(args.collection))
+    config = build_config(config_path)
+    spotify = get_spotify_client(config)
+    threshold = config.SPOTIFY_PLAYLIST_FUZZ_RATIO
+    tag_regex = re.compile(r"(?<=\/\*).*(?=\*\/)")
+    remove_tags = {"Opener", "Build", "Peak Time"}
+    tracks = collection.get_tracks().values()
+    with tqdm(total=len(tracks)) as pbar:
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(thread, track) for track in tracks]
+            for future in as_completed(futures):
+                future.result()
+                pbar.update(1)
+    collection.serialize(config_path.parent / f"auto_{config_path.name}")


### PR DESCRIPTION
Why?
My library is missing `year`, `album`, and `label` tags. I want to remove "situation" tags ("Opener", "Build", "Peak Time") because I'm repurposing the `rating` field to convey a track's energy level.
`build_config` should permit overriding the path to `config.yaml`

What?
Adds a script to map a threaded function to a collection's tracks. The function hits the Spotify API to find a matching track and resolves the `album`, `year`, and `label` fields. In addition, the `comments` are parsed for "My Tag" data and "situation" tags are removed.
Add an optional override to `config.yaml` in the `build_config` function.