### PR TITLE
feat: Make `MinimalDeepTechFilter` more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please see the [docs](https://a-rich.github.io/DJ-Tools/) for tutorials, how-to 
     - [x] Allow `build_config` to accept an override for the path to `config.yaml`
     - [x] Fix missing typehints for the `NonEmptyListElementAction` class
     - [ ] [Make PlaylistFilter implementations configurable](https://github.com/a-rich/DJ-Tools/issues/120)
-    - [ ] [Make MinimalDeepTechFilter more robust to the relative position of House and Techno tags](https://github.com/a-rich/DJ-Tools/issues/122)
+    - [x] [Make MinimalDeepTechFilter more robust to the relative position of House and Techno tags](https://github.com/a-rich/DJ-Tools/issues/122)
     - [ ] [Stability issues with requests to the search endpoint of the Spotify API](https://github.com/a-rich/DJ-Tools/issues/58)
     - [ ] [Make Spotify API calls asynchronous](https://github.com/a-rich/DJ-Tools/issues/38)
 * 2.7.0

--- a/djtools/collection/helpers.py
+++ b/djtools/collection/helpers.py
@@ -279,16 +279,18 @@ class MinimalDeepTechFilter(PlaylistFilter):
         Returns:
             Whether or not this track should be included in the playlist.
         """
-        genre_tags = track.get_genre_tags()
-        index = genre_tags.index("Minimal Deep Tech")
-        prefix_tag = genre_tags[index - 1]
-        techno_with_no_techno_prefix = (
-            self._techno and prefix_tag.lower() != "techno"
-        )
-        not_techno_with_techno_prefix = (
-            not self._techno and prefix_tag.lower() == "techno"
-        )
-        if techno_with_no_techno_prefix or not_techno_with_techno_prefix:
+        house_exp = re.compile(r".*house.*")
+        techno_exp = re.compile(r".*techno.*")
+        house_tag = techno_tag = False
+        for tag in track.get_genre_tags():
+            if re.search(house_exp, tag.lower()):
+                house_tag = True
+            if re.search(techno_exp, tag.lower()):
+                techno_tag = True
+        if (
+            (self._techno and not techno_tag) or
+            (self._house and not house_tag)
+        ):
             return False
 
         return True
@@ -306,10 +308,13 @@ class MinimalDeepTechFilter(PlaylistFilter):
             return False
 
         self._techno = False  #pylint: disable=attribute-defined-outside-init
+        self._house = False  #pylint: disable=attribute-defined-outside-init
         parent = playlist.get_parent()
         while parent:
             if parent.get_name() == "Techno":
                 self._techno = True  #pylint: disable=attribute-defined-outside-init
+            if parent.get_name() == "House":
+                self._house = True  #pylint: disable=attribute-defined-outside-init
             parent = parent.get_parent()
 
         return True

--- a/testing/collection/test_helpers.py
+++ b/testing/collection/test_helpers.py
@@ -152,6 +152,8 @@ def test_minimaldeeptechfilter(techno, genre_tags, expected, rekordbox_track):
     with mock.patch.object(
         track_filter, '_techno', techno, create=True
     ), mock.patch.object(
+        track_filter, '_house', not techno, create=True
+    ), mock.patch.object(
         RekordboxTrack, "get_genre_tags", lambda x: genre_tags
     ):
         result = track_filter.filter_track(rekordbox_track)


### PR DESCRIPTION
Why?
Successful application of the `MinimalDeepTechFilter` is sensitive to the relative positioning of tags matching `Techno` (case-insensitive). Instead, the track should only need to have any tag containing the substring `techno` to be placed under a playlist called `Techno` and, similarly, any tag containing the substring `house` to be placed under a playlist called `House`. Furthermore, if a track matches both substrings , it should be placed under both playlists.

What?
Check explicitly for `house` and `techno` substrings using regex. Explicitly identify a `House` parent playlist rather than simply `not Techno`.