### PR TITLE
feat: generalize string selectors

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -10,7 +10,7 @@ max-attributes=15
 
 max-branches=25
 
-max-locals=30
+max-locals=35
 
 max-statements=100
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Please see the [docs](https://a-rich.github.io/DJ-Tools/) for tutorials, how-to 
     - [x] [Make MinimalDeepTechFilter more robust to the relative position of House and Techno tags](https://github.com/a-rich/DJ-Tools/issues/122)
     - [x] [Standardize audio files](https://github.com/a-rich/DJ-Tools/issues/126)
     - [x] [Process recorded file using Spotify playlist](https://github.com/a-rich/DJ-Tools/issues/127)
+    - [x] [Improve selectors for Combiner playlists](https://github.com/a-rich/DJ-Tools/issues/131)
     - [ ] [Create graphic user interface for djtools](https://github.com/a-rich/DJ-Tools/issues/118)
     - [ ] [Derive boolean algebra expressions that generate a given playlist](https://github.com/a-rich/DJ-Tools/issues/106)
     - [ ] [Improve Reddit submission title parsing in order to improve precision and recall of Spotify API search results](https://github.com/a-rich/DJ-Tools/issues/59)

--- a/conftest.py
+++ b/conftest.py
@@ -38,8 +38,14 @@ def config():
     return joined_config
 
 
-@pytest.fixture
-def audio_file(tmpdir):
+@pytest.fixture(scope="session")
+def input_tmpdir(tmpdir_factory):
+    """Test tmpdir fixture."""
+    return tmpdir_factory.mktemp("input")
+
+
+@pytest.fixture(scope="session")
+def audio_file(input_tmpdir):  # pylint: disable=redefined-outer-name
     """Test audio file fixture."""
     headroom = -2
     audio = AudioSegment.silent(duration=1000).overlay(
@@ -47,16 +53,10 @@ def audio_file(tmpdir):
             headroom
         )
     )
-    _file = Path(tmpdir) / "file.mp3"
+    _file = Path(input_tmpdir) / "file.mp3"
     audio.export(_file, format="mp3")
 
-    return _file
-
-
-@pytest.fixture(scope="session")
-def input_tmpdir(tmpdir_factory):
-    """Test tmpdir fixture."""
-    return tmpdir_factory.mktemp("input")
+    return audio, _file
 
 
 @pytest.fixture

--- a/djtools/collection/collections.py
+++ b/djtools/collection/collections.py
@@ -45,7 +45,7 @@ class Collection(ABC):
         self._playlists.add_playlist(playlist)  # pylint:disable=no-member
 
     def get_playlists(
-        self, name: Optional[str] = None
+        self, name: Optional[str] = None, glob: Optional[bool] = False
     ) -> Union[Playlist, List[Playlist]]:
         """Returns Playlists with a matching name.
 
@@ -53,6 +53,7 @@ class Collection(ABC):
 
         Args:
             name: Name of the Playlists to return.
+            glob: Glob on playlist name containing "*".
 
         Returns:
             The Playlists with the same name.
@@ -60,13 +61,17 @@ class Collection(ABC):
         if not name:
             return self._playlists  # pylint:disable=no-member
 
+        exp = re.compile(r".*".join(name.split("*")))
         playlists = []
         for playlist in self._playlists:  # pylint:disable=no-member
-            if playlist.get_name() == name:
+            if (
+                (glob and re.search(exp, playlist.get_name())) or
+                (not glob and playlist.get_name() == name)
+            ):
                 playlists.append(playlist)
             if playlist.is_folder():
                 for playlist in playlist:
-                    playlists.extend(playlist.get_playlists(name))
+                    playlists.extend(playlist.get_playlists(name, glob=glob))
 
         return [playlist for playlist in playlists if playlist is not None]
 

--- a/djtools/collection/playlists.py
+++ b/djtools/collection/playlists.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 import inspect
 from pathlib import Path
+import re
 from typing import Any, Dict, List, Optional
 
 import bs4
@@ -92,11 +93,14 @@ class Playlist(ABC):
         """
         return self._parent
 
-    def get_playlists(self, name: Optional[str] = None) -> List[Playlist]:
+    def get_playlists(
+        self, name: Optional[str] = None, glob: Optional[bool] = False
+    ) -> List[Playlist]:
         """Returns Playlists with a matching name.
 
         Args:
             name: Name of the Playlists to return.
+            glob: Glob on playlist name containing "*".
 
         Returns:
             The Playlists with the same name.
@@ -109,12 +113,16 @@ class Playlist(ABC):
                 )
             return list(self)
 
+        exp = re.compile(r".*".join(name.split("*")))
         playlists = []
-        if self.get_name() == name:
+        if (
+            (glob and re.search(exp, self.get_name())) or
+            (not glob and self.get_name() == name)
+        ):
             playlists.append(self)
         if self.is_folder():
             for playlist in self:
-                playlists.extend(playlist.get_playlists(name))
+                playlists.extend(playlist.get_playlists(name, glob=glob))
 
         return [playlist for playlist in playlists if playlist is not None]
 

--- a/djtools/collection/tracks.py
+++ b/djtools/collection/tracks.py
@@ -19,6 +19,9 @@ from urllib.parse import quote, unquote
 import bs4
 
 
+# pylint: disable=no-member
+
+
 class Track(ABC):
     "Abstract base class for a track."
 
@@ -27,11 +30,35 @@ class Track(ABC):
         "Deserializes a track from the native format of a DJ software."
 
     @abstractmethod
+    def get_artists(self) -> str:
+        """Gets the track artists.
+
+        Returns:
+            A string representing the track's artists.
+        """
+
+    @abstractmethod
     def get_bpm(self) -> float:
         """Gets the track BPM.
 
         Returns:
             A float representing BPM.
+        """
+
+    @abstractmethod
+    def get_comments(self) -> str:
+        """Gets the track comments.
+
+        Returns:
+            A string representing the track's comments.
+        """
+
+    @abstractmethod
+    def get_date_added(self) -> str:
+        """Gets the track's date added.
+
+        Returns:
+            A datetime representing the track's date added.
         """
 
     @abstractmethod
@@ -48,6 +75,22 @@ class Track(ABC):
 
         Returns:
             The ID of this track.
+        """
+
+    @abstractmethod
+    def get_key(self) -> Any:
+        """Gets the track key.
+
+        Returns:
+            The key of this track.
+        """
+
+    @abstractmethod
+    def get_label(self) -> Any:
+        """Gets the track label.
+
+        Returns:
+            The label of this track.
         """
 
     @abstractmethod
@@ -72,6 +115,14 @@ class Track(ABC):
 
         Returns:
             A set of the track's tags.
+        """
+
+    @abstractmethod
+    def get_year(self) -> str:
+        """Gets the year of the track.
+
+        Returns:
+            The year of the track.
         """
 
     @abstractmethod
@@ -145,13 +196,13 @@ class RekordboxTrack(Track):
             setattr(self, f"_{key}", value)
 
         # Parse MyTag data from Comments attribute.
-        my_tags = re.search(r"(?<=\/\*).*(?=\*\/)", self._Comments)  # pylint: disable=no-member
+        my_tags = re.search(r"(?<=\/\*).*(?=\*\/)", self._Comments)
         self._MyTags = (  # pylint: disable=invalid-name
             [x.strip() for x in my_tags.group().split("/")] if my_tags else []
         )
 
         # Merge Genre and MyTag data into a new attribute.
-        self._Tags = set(self._Genre + self._MyTags)  # pylint: disable=no-member, invalid-name
+        self._Tags = set(self._Genre + self._MyTags)  # pylint: disable=invalid-name
 
         # Parse TEMPO Tags as the beat grid attribute.
         self._beat_grid = track.find_all("TEMPO")
@@ -221,13 +272,37 @@ class RekordboxTrack(Track):
         """
         return str(self.serialize())
 
+    def get_artists(self) -> str:
+        """Gets the track artists.
+
+        Returns:
+            A string representing the track's artists.
+        """
+        return self._Artist
+
     def get_bpm(self) -> float:
         """Gets the track BPM.
 
         Returns:
             A float representing BPM.
         """
-        return self._AverageBpm  # pylint: disable=no-member
+        return self._AverageBpm
+
+    def get_comments(self) -> str:
+        """Gets the track comments.
+
+        Returns:
+            A string representing the track's comments.
+        """
+        return self._Comments
+
+    def get_date_added(self) -> str:
+        """Gets the track's date added.
+
+        Returns:
+            A datetime representing the track's date added.
+        """
+        return self._DateAdded
 
     def get_genre_tags(self) -> List[str]:
         """Gets the genre tags of the track.
@@ -235,7 +310,7 @@ class RekordboxTrack(Track):
         Returns:
             A list of the track's genre tags.            
         """
-        return self._Genre  # pylint: disable=no-member
+        return self._Genre
 
     def get_id(self) -> str:
         """Get the track ID.
@@ -243,7 +318,23 @@ class RekordboxTrack(Track):
         Returns:
             The ID of this track.
         """
-        return self._TrackID  # pylint: disable=no-member
+        return self._TrackID
+
+    def get_key(self) -> Any:
+        """Gets the track key.
+
+        Returns:
+            The key of this track.
+        """
+        return self._Tonality
+
+    def get_label(self) -> Any:
+        """Gets the track label.
+
+        Returns:
+            The label of this track.
+        """
+        return self._Label
 
     def get_location(self) -> Path:
         """Gets the location of the track.
@@ -259,7 +350,7 @@ class RekordboxTrack(Track):
         Returns:
             The rating of the track.
         """
-        return self._Rating  # pylint: disable=no-member
+        return self._Rating
 
     def get_tags(self) -> Set[str]:
         """Gets the tags of the track.
@@ -268,6 +359,14 @@ class RekordboxTrack(Track):
             A set of the track's tags.
         """
         return self._Tags
+
+    def get_year(self) -> str:
+        """Gets the year of the track.
+
+        Returns:
+            The year of the track.
+        """
+        return self._Year
 
     def serialize(
         self, *args, playlist: bool = False, **kwargs
@@ -400,7 +499,7 @@ class RekordboxTrack(Track):
         Args:
             number: Number to set for TrackNumber.
         """
-        self._TrackNumber = number  # pylint: disable=invalid-name,attribute-defined-outside-init
+        self._TrackNumber = number  # pylint: disable=attribute-defined-outside-init,invalid-name
 
     @classmethod
     def validate(cls, original: bs4.element.Tag, serializable: RekordboxTrack):

--- a/djtools/configs/collection_playlists.yaml
+++ b/djtools/configs/collection_playlists.yaml
@@ -1,9 +1,10 @@
 combiner:
   name: Combinations
   playlists:
+    - "{artist:*Tribe*} | {comment:*Dark*} | {date:2022} | {date:<2022} | {key:7A} | {label:Some Label}"
     - "(Dubstep | Hip Hop) | (Dubstep | Hip Hop)"
-    - "{Hip Hop} & [85-87]"
-    - "{Hip Hop} & [86]"
+    - "{playlist:Hip Hop} & [85-87]"
+    - "{playlist:Hip Hop} & [86]"
     - Dark & [2-5]
     - Dark & [5]
 tags:

--- a/djtools/configs/helpers.py
+++ b/djtools/configs/helpers.py
@@ -523,6 +523,8 @@ def arg_parse() -> Namespace:
         print(__version__)
         sys.exit()
 
+    logger.info(f"djtools version: {__version__}")
+
     if args.link_configs:
         args.link_configs = Path(args.link_configs)
         if args.link_configs.exists():

--- a/djtools/version.py
+++ b/djtools/version.py
@@ -1,2 +1,2 @@
 """This module is the single source for this package's version."""
-__version__ = "2.7.0-b1"
+__version__ = "2.7.0-b2"

--- a/docs/how_to_guides/combiner_playlists.md
+++ b/docs/how_to_guides/combiner_playlists.md
@@ -27,12 +27,12 @@ There are many shortcomings with the Track Filter which make it far inferior to 
 The `Combiner` solves all these issues in the following ways:
 
 1. Portability
-    * generates regular playlists which can be exported to a device for use on any Pioneer system
-    * combining this with the [Copy Tracks From Playlists](../how_to_guides/copy_playlists.md) feature gives you portability on non-Pioneer systems
+    * generates regular playlists which can be exported to a device for use on any system
 1. Operands
-    * works on `My Tags` and `Genre` tags (and is extensible so other tags can be used as well)
-    * includes selector syntax to choose arbitrary number of BPM / rating values as well as arbitrary ranges of values
-    * includes selector syntax to choose playlists in your Collection
+    * works on any tag data that `djtools` knows of (e.g. genres, `My Tags`, etc.)
+    * includes numerical selector syntax to choose arbitrary rating, BPM, and year values as well as arbitrary ranges of values
+    * includes string selector syntax to choose playlists in your Collection as well as artists, comments, dates added, keys, and record labels
+    * any of the string selectors (except for `date`) support wildcard globbing with the `*` character
 1. Operators
     * adds a `NOT` operator to take the set difference
     * allows you to apply logic operators to *any* of the operands, not just `My Tags`
@@ -40,18 +40,68 @@ The `Combiner` solves all these issues in the following ways:
 
 ## Syntax
 
-* logical operators:
-    - `AND` = `&`
-    - `OR` = `|`
-    - `NOT` = `~`
-* playlist selectors:
-    - `{playlist name}`
-* BPM selectors (values > 5 are considered BPMs):
-    - `[80, 90, 130-150]`
-* rating selectors (values <= 5 are considered ratings):
-    - `[0, 1, 3-5]`
+* logical operators ("AND", "OR", "NOT"):
+    - `&`
+    - `|`
+    - `~`
+* string selectors:
+    - `{artist:*Eprom*}`
+    - `{comment:*hollaback*}`
+    - `{date:2022}`
+    - `{date:>2021-10-05}`
+    - `{date:<2020-05}`
+    - `{key:7A}`
+    - `{label:duploc}`
+    - `{playlist: Deep House}`
+* numerical selectors:
+    - `[0]`
+    - `[3-5]`
+    - `[80]`
+    - `[130-150]`
+    - `[1973]`
+    - `[2013-2023]`
 * grouping:
-    - `(`, `)`
+    - `(`
+    - `)`
+
+Let's look at an example playlist to see how the syntax works.
+
+Suppose we want a playlist with tracks that _all have_ the following properties:
+- from the years 2000 to 2023
+- and have a rating of 5
+- and with BPMs in the range 130 to 150
+
+The expression a.k.a. the combiner playlist name will look this:
+
+    [2000-2023] & [5] & [130-150]
+
+Now let's say we want to supplement that playlist with tracks that have _any one of_ the following properties:
+- have a genre tag called "Jungle"
+- or have another tag called "Dark"
+- or come from a playlist called "New Years 1999"
+- or come from the record label "Dispatch"
+
+The playlist for this set of tracks is expressed like this:
+
+    Jungle | Dark | {playlist: New Years 1999} | {label: Dispatch}
+
+Now we want to throw in a few more tracks using the other supported string selectors. We're also going to demonstrate the set difference operator `~` which will remove matching tracks from the resulting playlist. This subset of tracks will _all have_ the following properties:
+- have come from the artist "Eprom"
+- and have been added to the collection after 2010
+- and have the words "absolute banger" in the comments
+- and not have a major musical key (using [Camelot notation](https://mixedinkey.com/harmonic-mixing-guide/))
+
+The playlist for these tracks is written like this:
+
+    {artist: *Eprom*} & {date:>2010} & {comment:*absolute banger*} ~ {key:*A}
+
+Finally, let's see how we can create one master playlist from all three of these sub-expressions using groupings to ensure the proper order of operations:
+
+    ([2000-2023] & [5] & [130-150]) |
+    (Jungle | Dark | {playlist: New Years 1999} | {label: Dispatch}) |
+    ({artist: *Eprom*} & {date:>2010} & {comment:*absolute banger*} ~ {key:*A})
+    
+I hope you see how powerful the `Combiner` can become when used with a well indexed collection!
 
 ## How it's done
 

--- a/testing/data/rekordbox.xml
+++ b/testing/data/rekordbox.xml
@@ -3,12 +3,12 @@
 <DJ_PLAYLISTS Version="1.0.0">
   <PRODUCT Name="rekordbox" Version="6.6.4" Company="AlphaTheta"/>
   <COLLECTION>
-    <TRACK AverageBpm="140.00" Comments="/* Dark */" DateAdded="2023-06-24" Genre="Dubstep" Location="file://localhost/track1.mp3" Rating="255" TrackID="1" TrackNumber="1">
+    <TRACK Artist="Biome" AverageBpm="140.00" Comments="/* Dark */" DateAdded="2023-06-24" Genre="Dubstep" Label="Label" Location="file://localhost/track1.mp3" Tonality="7A" Rating="255" TrackID="1" TrackNumber="1" Year="2023">
       <TEMPO/>
       <POSITION_MARK/>
     </TRACK>
-    <TRACK AverageBpm="86.00" Comments="" DateAdded="2023-06-24" Genre="Hip Hop / R&amp;B" Location="file://localhost/track2.mp3" Rating="0" TrackID="2" TrackNumber="2"/>
-    <TRACK AverageBpm="128.00" Comments="" DateAdded="2023-06-24" Genre="Techno / Minimal Deep Tech" Location="file://localhost/track3.mp3" Rating="0" TrackID="3" TrackNumber="3"/>
+    <TRACK Artist="A Tribe Called Quest" AverageBpm="86.00" Comments="" DateAdded="2022-06-24" Genre="Hip Hop / R&amp;B" Label="Label" Location="file://localhost/track2.mp3" Tonality="7B" Rating="0" TrackID="2" TrackNumber="2" Year="2022"/>
+    <TRACK Artist="Carbon" AverageBpm="128.00" Comments="" DateAdded="2021-06-24" Genre="Techno / Minimal Deep Tech" Label="Some Label" Location="file://localhost/track3.mp3" Tonality="8A" Rating="0" TrackID="3" TrackNumber="3" Year="2021"/>
   </COLLECTION>
   <PLAYLISTS>
     <NODE Name="ROOT" Type="0" Count="2">

--- a/testing/utils/test_url_download.py
+++ b/testing/utils/test_url_download.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-from youtube_dl.utils import DownloadError
 
 from djtools.utils.url_download import fix_up, url_download
 
@@ -51,10 +50,3 @@ def test_url_download(tmpdir, config):
         context.download.side_effect = lambda *args, **kwargs: dummy_func()
         url_download(config)
     assert len(list(tmpdir.iterdir())) == 1
-
-
-def test_url_download_invalid_url(config):
-    """Test for the url_download function."""
-    config.URL_DOWNLOAD = ""
-    with pytest.raises(DownloadError):
-        url_download(config)


### PR DESCRIPTION
Why?
There are multiple attributes of tracks that ought to be selectable when using build_combiner_playlists.

What?
Re-brand the former BPM and rating selector as numerical selectors and add support for release year.
Re-brand the former playlist selector as string selectors and add support for:
- artist
- comment
- date added
- key
- label
- playlist