### PR TITLE
refactor: Collections serialize to same location

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -129,7 +129,7 @@ def rekordbox_xml(input_tmpdir):  # pylint: disable=redefined-outer-name
         with open(track.get_location(), mode="w", encoding="utf-8") as _file:
             _file.write("")
 
-    return collection.serialize(new_path=input_tmpdir / "rekordbox.xml")
+    return collection.serialize(output_path=input_tmpdir / "rekordbox.xml")
 
 
 @pytest.fixture(scope="session")

--- a/djtools/collection/collections.py
+++ b/djtools/collection/collections.py
@@ -218,12 +218,12 @@ class RekordboxCollection(Collection):
         self._playlists = RekordboxPlaylist(root, tracks=self._tracks)
 
     def serialize(
-        self, *args, new_path: Optional[Path] = None, **kwargs
+        self, *args, output_path: Optional[Path] = None, **kwargs
     ) -> Path:
         """Serializes this Collection as an XML file.
 
         Args:
-            new_path: Path to output serialized collection to.
+            output_path: Path to output serialized collection to.
 
         Returns:
             Path to the serialized collection XML file.
@@ -287,13 +287,12 @@ class RekordboxCollection(Collection):
         )
         doc.append(root_tag)
 
-        # If no new path is provided, use the original but prefix the file name
-        # with "auto_".
-        if not new_path:
-            new_path = self._path.parent / f"auto_{self._path.name}"
+        # If no new path is provided, use the original.
+        if not output_path:
+            output_path = self._path
 
         # Write the serialized Collection to a new file.
-        with open(new_path, mode="w", encoding="utf-8") as _file:
+        with open(output_path, mode="w", encoding="utf-8") as _file:
             _file.write(
                 doc.prettify(
                     # UnsortedAttributes formatter ensures attributes are
@@ -307,7 +306,7 @@ class RekordboxCollection(Collection):
                 )
             )
 
-        return new_path
+        return output_path
 
     @classmethod
     def validate(cls, input_xml: Path, output_xml: Path):

--- a/djtools/collection/copy_playlists.py
+++ b/djtools/collection/copy_playlists.py
@@ -10,6 +10,8 @@ The purpose of this utility is to:
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 import os
+from pathlib import Path
+from typing import Optional
 
 from tqdm import tqdm
 
@@ -17,13 +19,14 @@ from djtools.collection.helpers import copy_file, PLATFORM_REGISTRY
 from djtools.configs.config import BaseConfig
 
 
-def copy_playlists(config: BaseConfig):
+def copy_playlists(config: BaseConfig, output_path: Optional[Path] = None):
     """Copies tracks from provided playlists to a destination.
 
     Serializes the collection with these playlists and updated locations.
 
     Args:
         config: Configuration object.
+        output_path: Path to write the new collection to.
 
     Raises:
         LookupError: Playlist names in COPY_PLAYLISTS must exist in
@@ -88,4 +91,4 @@ def copy_playlists(config: BaseConfig):
         )
 
     # Serialize the new collection.
-    _ = collection.serialize()
+    _ = collection.serialize(output_path=output_path)

--- a/djtools/collection/playlist_builder.py
+++ b/djtools/collection/playlist_builder.py
@@ -2,6 +2,7 @@
 from collections import defaultdict
 import logging
 from pathlib import Path
+from typing import Optional
 
 import yaml
 
@@ -22,7 +23,9 @@ from djtools.configs.config import BaseConfig
 logger = logging.getLogger(__name__)
 
 
-def collection_playlists(config: BaseConfig):
+def collection_playlists(
+    config: BaseConfig, output_path: Optional[Path] = None
+):
     """Builds playlists automatically.
 
     By maintaining a collection with tracks having tag data (e.g. genre tags,
@@ -72,6 +75,7 @@ def collection_playlists(config: BaseConfig):
 
     Args:
         config: Configuration object.
+        output_path: Path to write the new collection to.
     """
     # Load the playlist config.
     with open(
@@ -193,4 +197,4 @@ def collection_playlists(config: BaseConfig):
     auto_playlist.set_parent(collection.get_playlists())
     collection.reset_playlists()
     collection.add_playlist(auto_playlist)
-    collection.serialize()
+    collection.serialize(output_path=output_path)

--- a/djtools/collection/shuffle_playlists.py
+++ b/djtools/collection/shuffle_playlists.py
@@ -6,7 +6,9 @@ playlist(s).
 from concurrent.futures import as_completed, ThreadPoolExecutor
 import logging
 import os
+from pathlib import Path
 import random
+from typing import Optional
 
 from tqdm import tqdm
 
@@ -17,12 +19,13 @@ from djtools.collection.helpers import PLATFORM_REGISTRY
 logger = logging.getLogger(__name__)
 
 
-def shuffle_playlists(config: BaseConfig):
+def shuffle_playlists(config: BaseConfig, output_path: Optional[Path] = None):
     """For each playlist in "SHUFFLE_PLAYLISTS", shuffle the tracks and
     sequentially set the track number to emulate shuffling.
 
     Args:
         config: Configuration object.
+        output_path: Path to write the new collection to.
     """
     # Load collection.
     collection = PLATFORM_REGISTRY[config.PLATFORM]["collection"](
@@ -65,4 +68,4 @@ def shuffle_playlists(config: BaseConfig):
             tracks={track.get_id(): track for track in shuffled_tracks},
         )
     )
-    _ = collection.serialize()
+    _ = collection.serialize(output_path=output_path)

--- a/djtools/sync/helpers.py
+++ b/djtools/sync/helpers.py
@@ -101,7 +101,7 @@ def rewrite_track_paths(config: BaseConfig, other_user_collection: Path):
             music_path / loc.split(str(music_path) + '/', maxsplit=-1)[-1]
         )
         track.set_location(config.USB_PATH / common_path)
-    collection.serialize(new_path=other_user_collection)
+    collection.serialize(output_path=other_user_collection)
 
 
 def run_sync(_cmd: str) -> str:

--- a/docs/tutorials/getting_started/configuration.md
+++ b/docs/tutorials/getting_started/configuration.md
@@ -11,7 +11,7 @@ In fact, removing the template `config.yaml` and building a config from scratch 
 
 ## [Collection config][djtools.collection.config.CollectionConfig]
 * `COLLECTION_PATH`: the full path to your collection...the parent directory where this points to is also where all other collections generated or utilized by this library will exist
-* `COLLECTION_PLAYLISTS`: boolean flag to trigger the generation of a playlist structure (as informed by `collection_playlists.yaml`) using the tags in `COLLECTION_PATH`...the resulting collection is the file at `COLLECTION_PATH` prefixed with "`auto_`"
+* `COLLECTION_PLAYLISTS`: boolean flag to trigger the generation of a playlist structure (as informed by `collection_playlists.yaml`) using the tags in `COLLECTION_PATH`...the resulting collection is the file at `COLLECTION_PATH`
 * `COLLECTION_PLAYLISTS_REMAINDER`: whether tracks of remainder tags (those not specified in `collection_playlists.yaml`) will be placed in a `folder` called "Other" with individual tag playlists or a `playlist` called "Other"
 * `COLLECTION_PLAYLIST_FILTERS`: list of `PlaylistFilter` classes used to apply special filtering logic to tag playlists
 * `COPY_PLAYLISTS`: list of playlists in `COLLECTION_PATH` to (a) have audio files copied and (b) have track data written to a new collection with updated locations

--- a/testing/collection/test_collections.py
+++ b/testing/collection/test_collections.py
@@ -49,8 +49,9 @@ def test_rekordboxcollection(
     repr(collection)
     str(collection)
     playlist = collection.get_playlists(playlist)
-    serialized_collection = collection.serialize()
-    assert serialized_collection.exists()
+    new_path = rekordbox_xml.parent / "test_collection"
+    serialized_collection = collection.serialize(output_path=new_path)
+    assert new_path.exists()
     RekordboxCollection.validate(rekordbox_xml, serialized_collection)
 
 

--- a/testing/collection/test_copy_playlists.py
+++ b/testing/collection/test_copy_playlists.py
@@ -16,7 +16,7 @@ def test_copy_playlists(tmpdir, config, rekordbox_xml):
     config.COLLECTION_PATH = rekordbox_xml
     config.COPY_PLAYLISTS = target_playlists
     config.COPY_PLAYLISTS_DESTINATION = Path(test_output_dir)
-    copy_playlists(config)
+    copy_playlists(config, output_path=new_xml)
     assert list(test_output_dir.iterdir())
     assert new_xml.exists()
     with open(new_xml, mode="r", encoding="utf-8") as _file:

--- a/testing/collection/test_playlist_builder.py
+++ b/testing/collection/test_playlist_builder.py
@@ -18,7 +18,9 @@ def test_collection_playlists(remainder_type, config, rekordbox_xml):
     config.COLLECTION_PLAYLISTS_REMAINDER = remainder_type
     config.COLLECTION_PATH = rekordbox_xml
     config.VERBOSITY = 1
-    collection_playlists(config)
+    collection_playlists(
+        config, output_path=rekordbox_xml.parent / "test_collection"
+    )
 
 
 @mock.patch(
@@ -31,7 +33,9 @@ def test_collection_playlists_with_empty_playlistconfig_returns_early(
     """Test for the collection_playlists function."""
     caplog.set_level("WARNING")
     config.COLLECTION_PATH = rekordbox_xml
-    collection_playlists(config)
+    collection_playlists(
+        config, output_path=rekordbox_xml.parent / "test_collection"
+    )
     assert caplog.records[0].message == (
         "Not building playlists because the playlist config is empty."
     )

--- a/testing/collection/test_shuffle_playlists.py
+++ b/testing/collection/test_shuffle_playlists.py
@@ -28,8 +28,8 @@ def test_shuffle_playlists(config, rekordbox_xml, caplog):
     original_track_numbers = [
         track_lookup[key]["TrackNumber"] for key in original_tracks
     ]
-    shuffle_playlists(config)
-    new_xml = rekordbox_xml.parent / f"auto_{rekordbox_xml.name}"
+    new_xml = rekordbox_xml.parent / "test_collection"
+    shuffle_playlists(config, output_path=new_xml)
     with open(new_xml, mode="r", encoding="utf-8") as _file:
         database = BeautifulSoup(_file.read(), "xml")
     track_lookup = {

--- a/testing/sync/test_helpers.py
+++ b/testing/sync/test_helpers.py
@@ -88,7 +88,7 @@ def test_rewrite_track_paths(config, rekordbox_xml):
         track.set_location(
             loc.parent / str(user_a_path).strip("/") / "DJ Music" / loc.name
         )
-    collection.serialize(new_path=user_a_xml)
+    collection.serialize(output_path=user_a_xml)
 
     # Write the second user's USB_PATH into each track.
     collection = RekordboxCollection(user_b_xml)
@@ -97,7 +97,7 @@ def test_rewrite_track_paths(config, rekordbox_xml):
         track.set_location(
             loc.parent / str(user_b_path).strip("/") / "DJ Music" / loc.name
         )
-    collection.serialize(new_path=user_b_xml)
+    collection.serialize(output_path=user_b_xml)
 
     rewrite_track_paths(config, user_b_xml)
 


### PR DESCRIPTION
Why?
With the upcoming GUI work item, having to update the COLLECTION_PATH config with the "auto_" collection output when serializing would be annoying.

What?
Have collections serialize to the same path they are read from.