### PR TITLE
refactor: deprecate reset_playlists

### DIFF
--- a/djtools/collection/collections.py
+++ b/djtools/collection/collections.py
@@ -102,10 +102,6 @@ class Collection(ABC):
         return self._tracks
 
     @abstractmethod
-    def reset_playlists(self):
-        """Resets the Playlists in the Collection to be empty."""
-
-    @abstractmethod
     def serialize(self, *args, **kwargs) -> Path:
         """Serialize a collection into the native format of a DJ software.
 
@@ -209,13 +205,6 @@ class RekordboxCollection(Collection):
             Collection represented as a string.
         """
         return str(self.serialize())
-
-    def reset_playlists(self):
-        """Resets the Playlists in the Collection to be empty."""
-        root = self._collection.find("NODE", {"Name": "ROOT", "Type": "0"})
-        for child in list(root.children):
-            child.extract()
-        self._playlists = RekordboxPlaylist(root, tracks=self._tracks)
 
     def serialize(
         self, *args, output_path: Optional[Path] = None, **kwargs

--- a/djtools/collection/copy_playlists.py
+++ b/djtools/collection/copy_playlists.py
@@ -90,5 +90,10 @@ def copy_playlists(config: BaseConfig, output_path: Optional[Path] = None):
             )
         )
 
+    # Unless specified, write the output collection to the same directory that
+    # the files are being copied to.
+    if not output_path:
+        output_path = config.COPY_PLAYLISTS_DESTINATION / "copied_playlists_collection"
+
     # Serialize the new collection.
     _ = collection.serialize(output_path=output_path)

--- a/djtools/collection/playlist_builder.py
+++ b/djtools/collection/playlist_builder.py
@@ -189,12 +189,10 @@ def collection_playlists(
         if config.VERBOSITY and combiner_playlists:
             print_playlists_tag_statistics(combiner_playlists)
 
-    # Reset the collection's playlists and insert a new playlist containing
-    # the built playlists.
+    # Insert a new playlist containing the built playlists.
     auto_playlist = playlist_class.new_playlist(
         name="PLAYLIST_BUILDER", playlists=auto_playlists
     )
     auto_playlist.set_parent(collection.get_playlists())
-    collection.reset_playlists()
     collection.add_playlist(auto_playlist)
     collection.serialize(output_path=output_path)

--- a/djtools/collection/shuffle_playlists.py
+++ b/djtools/collection/shuffle_playlists.py
@@ -59,9 +59,7 @@ def shuffle_playlists(config: BaseConfig, output_path: Optional[Path] = None):
         ):
             _ = future.result()
 
-    # Reset the collection's playlists and insert a new playlist containing
-    # just the shuffled tracks.
-    collection.reset_playlists()
+    # Insert a new playlist containing just the shuffled tracks.
     collection.add_playlist(
         PLATFORM_REGISTRY[config.PLATFORM]["playlist"].new_playlist(
             name="SHUFFLE",

--- a/djtools/version.py
+++ b/djtools/version.py
@@ -1,2 +1,2 @@
 """This module is the single source for this package's version."""
-__version__ = "2.7.0-b3"
+__version__ = "2.7.0-b4"

--- a/testing/collection/test_collections.py
+++ b/testing/collection/test_collections.py
@@ -58,10 +58,9 @@ def test_rekordboxcollection(
 def test_rekordboxcollection_add_playlist(rekordbox_xml):
     """Test RekordboxCollection class."""
     collection = RekordboxCollection(path=rekordbox_xml)
-    collection.reset_playlists()
-    assert len(collection.get_playlists()) == 0
+    num_playlists = len(collection.get_playlists())
     collection.add_playlist([])
-    assert len(collection.get_playlists()) == 1
+    assert len(collection.get_playlists()) == num_playlists + 1
 
 
 def test_rekordboxcollection_get_all_tags(rekordbox_collection):
@@ -78,22 +77,6 @@ def test_rekordboxcollection_get_all_tags(rekordbox_collection):
     }
     tags = rekordbox_collection.get_all_tags()
     assert tags == expected
-
-
-def test_rekordboxcollection_reset_playlists(
-    rekordbox_xml, rekordbox_collection_tag
-):
-    """Test RekordboxCollection class."""
-    collection = RekordboxCollection(path=rekordbox_xml)
-    top_level_playlists = [
-        child for child in rekordbox_collection_tag.find(
-            "NODE", {"Name": "ROOT"}
-        ).children
-        if isinstance(child, bs4.element.Tag)
-    ]
-    assert len(collection.get_playlists()) == len(top_level_playlists)
-    collection.reset_playlists()
-    assert len(collection.get_playlists()) == 0
 
 
 def test_unsortedattributes_formatter():

--- a/testing/collection/test_copy_playlists.py
+++ b/testing/collection/test_copy_playlists.py
@@ -11,15 +11,15 @@ from djtools.collection.copy_playlists import copy_playlists
 def test_copy_playlists(tmpdir, config, rekordbox_xml):
     """Test for the copy_playlists function."""
     target_playlists = ["Hip Hop", "Dark"]
-    new_xml = rekordbox_xml.parent / "auto_rekordbox.xml"
     test_output_dir = Path(tmpdir) / "output"
     config.COLLECTION_PATH = rekordbox_xml
     config.COPY_PLAYLISTS = target_playlists
     config.COPY_PLAYLISTS_DESTINATION = Path(test_output_dir)
-    copy_playlists(config, output_path=new_xml)
+    new_collection = config.COPY_PLAYLISTS_DESTINATION / "copied_playlists_collection"
+    copy_playlists(config)
     assert list(test_output_dir.iterdir())
-    assert new_xml.exists()
-    with open(new_xml, mode="r", encoding="utf-8") as _file:
+    assert new_collection.exists()
+    with open(new_collection, mode="r", encoding="utf-8") as _file:
         xml = BeautifulSoup(_file.read(), "xml")
     for track in xml.find_all("TRACK"):
         if not track.get("Location"):


### PR DESCRIPTION
Why?
Collection operations should be non-destructive.

What?
shuffle_playlists and collection_playlists  no longer reset_playlists (i.e clear all data before inserting new playlists).

copy_playlists, unless an output_path is explicitly provided, will write the output collection to the same directory as
COPY_PLAYLISTS_DESTINATION.