### PR TITLE
refactor: url_download uses AUDIO_* configs

### DIFF
--- a/djtools/utils/normalize_audio.py
+++ b/djtools/utils/normalize_audio.py
@@ -9,6 +9,8 @@ from djtools.utils.helpers import get_local_tracks
 
 
 logger = logging.getLogger(__name__)
+pydub_logger = logging.getLogger("pydub.converter")
+pydub_logger.setLevel(logging.CRITICAL)
 
 
 def normalize(config: BaseConfig):

--- a/djtools/utils/process_recording.py
+++ b/djtools/utils/process_recording.py
@@ -19,6 +19,8 @@ from djtools.utils.helpers import get_spotify_tracks
 
 
 logger = logging.getLogger(__name__)
+pydub_logger = logging.getLogger("pydub.converter")
+pydub_logger.setLevel(logging.CRITICAL)
 
 
 def process(config: BaseConfig):
@@ -106,7 +108,7 @@ def process(config: BaseConfig):
         # of djtools.
         if str(filename).count(" - ") > 1:
             logger.warning(
-                f'{filename} has at more than one occurrence of " - "! '
+                f'{filename} has more than one occurrence of " - "! '
                 "Because djtools splits on this sequence of characters to "
                 "separate track title and artist(s), you might get unexpected "
                 'behavior while using features like "--check-tracks".'

--- a/djtools/utils/url_download.py
+++ b/djtools/utils/url_download.py
@@ -42,13 +42,12 @@ def url_download(config: BaseConfig):
     dl_loc.mkdir(parents=True, exist_ok=True)
 
     ydl_opts = {
-        "format": "bestaudio/best",
         "postprocessors": [{
             "key": "FFmpegExtractAudio",
-            "preferredcodec": "mp3",
-            "preferredquality": "320",
+            "preferredcodec": config.AUDIO_FORMAT,
+            "preferredquality": config.AUDIO_BITRATE.rstrip("k"),
         }],
-        "outtmpl": (dl_loc / "%(title)s.%(ext)s").as_posix()
+        "outtmpl": (dl_loc / "%(title)s.tmp").as_posix()
     }
 
     with ytdl.YoutubeDL(ydl_opts) as ydl:

--- a/djtools/version.py
+++ b/djtools/version.py
@@ -1,2 +1,2 @@
 """This module is the single source for this package's version."""
-__version__ = "2.7.0-b5"
+__version__ = "2.7.0-b6"

--- a/testing/utils/test_normalize_audio.py
+++ b/testing/utils/test_normalize_audio.py
@@ -9,6 +9,9 @@ from djtools.utils.normalize_audio import normalize
 
 @mock.patch("djtools.utils.normalize_audio.effects.normalize")
 @pytest.mark.parametrize("target_headroom", [0, 2, 5])
+@mock.patch(
+    "djtools.utils.process_recording.AudioSegment.export", mock.Mock()
+)
 def test_normalize(mock_normalize, target_headroom, audio_file, config, input_tmpdir):
     """Test for the normalize function."""
     config.AUDIO_HEADROOM = target_headroom


### PR DESCRIPTION
Why?
url_download was previously writing files with a fixed mp3 codec and 320k bitrate. Also, youtube-dl does not apply postprocessors if the downloaded file is the same path as the would-be postprocessed file.

What?
Use AUDIO_FORMAT and AUDIO_BITRATE config options. Have the downloaded file use .tmp extension so postprocessing is done.

Note:
The `youtube-dl` package has bug where postprocessing of mp3s is ignored.
https://github.com/a-rich/youtube-dl/tree/fix-ffmpeg-mp3-postprocessing

test: mock pydub.AudioSegment.export and decrease verbosity

Why?
The pydub logger messes up the Github Action's ability to format test results. Also, exporting takes up valuable test time.

What?
Mock the export function properly and decrease the pydub.converter logger to CRITICAL messages in the test modules.