### PR TITLE
feat: supported nested combiner playlists

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,7 +11,7 @@ import pytest
 import yaml
 
 from djtools.configs.config import BaseConfig
-from djtools.configs.helpers import filter_dict, pkg_cfg
+from djtools.configs.helpers import filter_dict, PKG_CFG
 from djtools.collection.collections import RekordboxCollection
 from djtools.collection.playlists import RekordboxPlaylist
 from djtools.collection.tracks import RekordboxTrack
@@ -27,7 +27,7 @@ def namespace():
 @mock.patch("djtools.spotify.helpers.get_spotify_client", mock.MagicMock())
 def config():
     """Test config fixture."""
-    configs = {pkg: cfg() for pkg, cfg in pkg_cfg.items() if pkg != "configs"}
+    configs = {pkg: cfg() for pkg, cfg in PKG_CFG.items() if pkg != "configs"}
     joined_config = BaseConfig(
         **{
             k: v for cfg in configs.values()

--- a/djtools/collection/playlist_builder.py
+++ b/djtools/collection/playlist_builder.py
@@ -175,12 +175,12 @@ def collection_playlists(
         # Parse selectors from the combiner playlist names and update the
         # tags_tracks mapping.
         add_selectors_to_tags(
-            playlist_config, tags_tracks, collection, auto_playlists
+            playlist_config.combiner, tags_tracks, collection, auto_playlists
         )
 
         # Evaluate the boolean logic of the combiner playlists.
         combiner_playlists = build_combiner_playlists(
-            playlist_config, tags_tracks, playlist_class
+            playlist_config.combiner, tags_tracks, playlist_class
         )
 
         auto_playlists.append(combiner_playlists)

--- a/djtools/collection/playlists.py
+++ b/djtools/collection/playlists.py
@@ -399,13 +399,13 @@ class RekordboxPlaylist(Playlist):
         playlist_tag = bs4.Tag(
             name="NODE",
             attrs=(
-               {"Name": name, "Type": "0", "Count": len(playlists)}
-               if playlists else {
-                   "Name": name,
-                   "Type": "1",
-                   "KeyType": "0",
-                   "Entries": len(tracks),
-               }
+            {"Name": name, "Type": "0", "Count": len(playlists)}
+            if playlists is not None else {
+                "Name": name,
+                "Type": "1",
+                "KeyType": "0",
+                "Entries": len(tracks),
+            }
             ),
         )
         playlist = RekordboxPlaylist(

--- a/djtools/configs/collection_playlists.yaml
+++ b/djtools/configs/collection_playlists.yaml
@@ -1,12 +1,21 @@
 combiner:
   name: Combinations
   playlists:
+    - name: Empty playlists folder
+      playlists: [] 
+    - name: Dark
+      playlists: 
+        - Dark & [2-5]
+        - Dark & [5]
+    - name: Hip Hop
+      playlists:
+        - "{playlist:Hip Hop} & [85-87]"
+        - "{playlist:Hip Hop} & [86]"
+    - name: Dubstep
+      playlists:
+        - "(Dubstep | Hip Hop) | (Dubstep | Hip Hop)"
+        - "Dubstep & {date:<2022} & [5]"
     - "{artist:*Tribe*} | {comment:*Dark*} | {date:2022} | {date:<2022} | {key:7A} | {label:Some Label}"
-    - "(Dubstep | Hip Hop) | (Dubstep | Hip Hop)"
-    - "{playlist:Hip Hop} & [85-87]"
-    - "{playlist:Hip Hop} & [86]"
-    - Dark & [2-5]
-    - Dark & [5]
 tags:
   name: "Tags"
   playlists:
@@ -26,7 +35,6 @@ tags:
           playlists:
             - name: Breaks
               playlists:
-                - Breakstep
                 - Neurobreaks
             - name: Hip Hop Beats
               playlists:
@@ -36,7 +44,6 @@ tags:
             - Space Bass
             - name: "[___] Step"
               playlists:
-                - Breakstep
                 - Dubstep
                 - Pure Dubstep
         - Hip Hop

--- a/djtools/configs/helpers.py
+++ b/djtools/configs/helpers.py
@@ -21,7 +21,7 @@ from djtools.version import __version__
 
 logger = logging.getLogger(__name__)
 
-pkg_cfg = {
+PKG_CFG = {
     "collection": CollectionConfig,
     "configs": BaseConfig,
     "spotify": SpotifyConfig,
@@ -580,7 +580,7 @@ def build_config(config_file: Optional[Path] = None) -> BaseConfig:
                 k: v.default for k, v in cfg.__fields__.items()
                 if pkg == "configs" or k not in base_config_fields
             }
-            for pkg, cfg in pkg_cfg.items()
+            for pkg, cfg in PKG_CFG.items()
         }
         with open(config_file, mode="w", encoding="utf-8") as _file:
             yaml.dump(initial_config, _file)
@@ -593,7 +593,7 @@ def build_config(config_file: Optional[Path] = None) -> BaseConfig:
     if args:
         logger.info(f"Args: {args}")
         args_set = set(args)
-        for pkg, cfg_class in pkg_cfg.items():
+        for pkg, cfg_class in PKG_CFG.items():
             args_intersection = set(cfg_class.__fields__).intersection(args_set)
             if args_intersection:
                 args_subset = {
@@ -608,7 +608,7 @@ def build_config(config_file: Optional[Path] = None) -> BaseConfig:
     base_cfg_options = config["configs"] if config else {}
     configs = {
         pkg: cfg(**{**base_cfg_options, **config.get(pkg, {})})
-        for pkg, cfg in pkg_cfg.items() if pkg != "configs"
+        for pkg, cfg in PKG_CFG.items() if pkg != "configs"
     }
     joined_config = BaseConfig(
         **base_cfg_options,

--- a/djtools/utils/config.py
+++ b/djtools/utils/config.py
@@ -5,10 +5,12 @@ config.yaml
 import logging
 import os
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 from typing_extensions import Literal
 
-from pydantic import NonNegativeFloat, NonNegativeInt, validator
+from pydantic import (
+    NonNegativeFloat, NonNegativeInt, root_validator, validator
+)
 
 from djtools.configs.config import BaseConfig
 
@@ -85,20 +87,22 @@ class UtilsConfig(BaseConfig):
 
         return str(value)
 
-    @validator("AUDIO_FORMAT")
+    @root_validator
     @classmethod
-    def format_validation(cls, value: str) -> str:
+    def format_validation(cls, values: Dict) -> str:
         """Logs a warning message to install FFmpeg if AUDIO_FORMAT isn't wav.
 
         Args:
-            value: AUDIO_FORMAT field
+            values: All model fields.
 
         Returns:
-            The AUDIO_FORMAT field.
+            Dict of all model fields.
         """
-        if value != "wav":
+        if values["AUDIO_FORMAT"] != "wav" and (
+            values["NORMALIZE_AUDIO"] or values["PROCESS_RECORDING"]
+        ):
             logger.warning(
                 "You must install FFmpeg in order to use non-wav file formats."
             )
 
-        return value
+        return values

--- a/djtools/version.py
+++ b/djtools/version.py
@@ -1,2 +1,2 @@
 """This module is the single source for this package's version."""
-__version__ = "2.7.0-b7"
+__version__ = "2.7.0-b8"

--- a/testing/collection/test_helpers.py
+++ b/testing/collection/test_helpers.py
@@ -6,20 +6,23 @@ from unittest import mock
 
 import pytest
 
-from djtools.collection.collections import RekordboxCollection
+from djtools.collection.collections import Collection, RekordboxCollection
 from djtools.collection.helpers import (
     BooleanNode,
     copy_file,
     # aggregate_playlists,
+    build_combiner_playlists,
     build_tag_playlists,
     HipHopFilter,
     MinimalDeepTechFilter,
     parse_numerical_selectors,
     parse_string_selectors,
+    PLATFORM_REGISTRY,
     print_data,
     print_playlists_tag_statistics,
     scale_data,
 )
+from djtools.collection.playlists import Playlist
 from djtools.collection.tracks import RekordboxTrack
 
 
@@ -90,17 +93,24 @@ def test_booleannode_raises_runtime_eror():
         node.evaluate()
 
 
-def test_build_tag_playlists():
-    """Test the create_playlists function."""
-
-
-def test_build_tag_playlists_raises_exception_():
-    """Test the create_playlists function."""
+def test_build_combiner_playlists_raises_exception_():
+    """Test the build_combiner_playlists function."""
     with pytest.raises(
         ValueError,
         match=re.escape(f"Invalid input type {list}: {[]}"),
     ):
-        build_tag_playlists([], {}, set())
+        software_config = PLATFORM_REGISTRY[next(iter(PLATFORM_REGISTRY))]
+        build_combiner_playlists([], {}, software_config["playlist"])
+
+
+def test_build_tag_playlists_raises_exception_():
+    """Test the build_tag_playlists function."""
+    with pytest.raises(
+        ValueError,
+        match=re.escape(f"Invalid input type {list}: {[]}"),
+    ):
+        software_config = PLATFORM_REGISTRY[next(iter(PLATFORM_REGISTRY))]
+        build_tag_playlists([], {}, software_config["playlist"])
 
 
 def test_copy_file(tmpdir, rekordbox_track):
@@ -242,6 +252,18 @@ def test_parse_string_selectors_warns_bad(matches, expected, caplog):
     caplog.set_level("WARNING")
     parse_string_selectors(matches, {}, {"date": "get_date_added"}, set())
     assert caplog.records[0].message == expected
+
+
+def test_platform_registry():
+    """Test for the PLATFORM_REGISTRY object."""
+    assert isinstance(PLATFORM_REGISTRY, dict)
+    assert len(PLATFORM_REGISTRY)
+    for registered_software, impls in PLATFORM_REGISTRY.items():
+        assert isinstance(registered_software, str)
+        assert isinstance(impls, dict)
+        for impl_type, impl_class in impls.items():
+            assert impl_type in ["collection", "playlist"]
+            assert set(impl_class.__bases__).intersection(set((Collection, Playlist)))
 
 
 def test_print_data(capsys):

--- a/testing/configs/test_helpers.py
+++ b/testing/configs/test_helpers.py
@@ -13,7 +13,7 @@ from djtools.configs.helpers import (
     convert_to_paths,
     filter_dict,
     parse_json,
-    pkg_cfg,
+    PKG_CFG,
 )
 from djtools.utils.helpers import MockOpen
 from djtools.version import __version__
@@ -118,7 +118,7 @@ def test_convert_to_paths(paths):
         assert isinstance(paths, Path)
 
 
-@pytest.mark.parametrize("config", pkg_cfg.values())
+@pytest.mark.parametrize("config", PKG_CFG.values())
 @mock.patch("djtools.spotify.helpers.get_spotify_client", mock.Mock())
 def test_filter_dict(config):
     """Test for the filter_dict function."""


### PR DESCRIPTION
Why?
To make organizing those projects easier and more flexible.

What?
Make the parts of the build_combiner_playlists call stack that touch PlaylistConfigContent.playlists work recursively.

test: suppress FFmpeg warning, test PLATFORM_REGISTRY

Why?
FFmpeg should only warn using normalize_audio or processing_recording. It should be asserted that contributions to the PLATFORM_REGISTRY object meet expectations.

What?
Add a root_validator to UtilsConfig.
Add test case for checking the type structure of PLATFORM_REGISTRY.