### PR TITLE
ci: cache python and update mkdocstrings-python

### DIFF
--- a/.github/workflows/deploy-dev-docs.yaml
+++ b/.github/workflows/deploy-dev-docs.yaml
@@ -26,6 +26,11 @@ jobs:
           python-version: 3.9
           cache: 'pip'
 
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/deploy-prod-docs.yaml
+++ b/.github/workflows/deploy-prod-docs.yaml
@@ -19,6 +19,11 @@ jobs:
           python-version: 3.9
           cache: 'pip'
 
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -24,6 +24,11 @@ jobs:
           python-version: 3.9
           cache: 'pip'
 
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -24,6 +24,11 @@ jobs:
           python-version: 3.9
           cache: 'pip'
 
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,11 @@ jobs:
           python-version: 3.9
           cache: 'pip'
 
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/development-requirements.txt
+++ b/development-requirements.txt
@@ -6,7 +6,7 @@ fuzzywuzzy==0.18.0
 lxml==4.9.2
 mkdocs==1.4.2
 mkdocs-material==9.1.8
-mkdocstrings-python==0.9.0
+mkdocstrings-python==1.6.0
 pydantic==1.9.1
 pydub==0.25.1
 pylint==2.17.3


### PR DESCRIPTION
Why?
Bug in griffe is causing mkdocs deployments to fail (see below). Caching is good.

What?
Update mkdocstrings-python from 0.9.0 to 1.6.0. Add caching action to each workflow.