### PR TITLE
ci: restrict paths for workflow triggers

### DIFF
--- a/.github/workflows/deploy-dev-docs.yaml
+++ b/.github/workflows/deploy-dev-docs.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - 'releases/**'
     paths:
-      - '**.md'
+      - 'docs/**.md'
 
 jobs:
   build:

--- a/.github/workflows/deploy-prod-docs.yaml
+++ b/.github/workflows/deploy-prod-docs.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     paths:
-      - '**.md'
+      - 'docs/**.md'
 
 jobs:
   build:

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -1,6 +1,8 @@
 name: Pylint
 on:
-  - pull_request
+  pull_request:
+    paths:
+      - 'djtools/**.py'
 
 jobs:
   build:

--- a/.github/workflows/pytest-coverage.yaml
+++ b/.github/workflows/pytest-coverage.yaml
@@ -1,6 +1,8 @@
 name: Pytest Coverage
 on:
-  - pull_request
+  pull_request:
+    paths:
+      - 'djtools/**.py'
 
 jobs:
   build:

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -5,8 +5,8 @@ on:
       - 'releases/*'
     paths:
       - 'requirements.txt'
-      - '**.py'
-      - '!**/*version.py'
+      - 'djtools/**.py'
+      - '!djtools/version.py'
 
 jobs:
   build:

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -5,8 +5,8 @@ on:
       - main
     paths:
       - 'requirements.txt'
-      - '**.py'
-      - '!**/*version.py'
+      - 'djtools/**.py'
+      - '!djtools/version.py'
 
 jobs:
   build:


### PR DESCRIPTION
Why?
Path matches for workflows were too broad.

What?
Docs deployments should only happen if markdown files underneath "docs" are touched.

Testing, linting, and releasing should only occur if Python under "djtools" are touched.