### PR TITLE
docs: add developer docs, playlist_filters module

### DIFF
--- a/djtools/collection/helpers.py
+++ b/djtools/collection/helpers.py
@@ -1,6 +1,5 @@
 """This module contains helpers for the collection package."""
 from __future__ import annotations
-from abc import ABC, abstractmethod
 from collections import defaultdict
 from datetime import datetime
 import logging
@@ -12,6 +11,7 @@ from typing import Dict, List, Optional, Set, Tuple, Union
 
 from djtools.collection.collections import Collection, RekordboxCollection
 from djtools.collection.config import PlaylistConfig, PlaylistConfigContent
+from djtools.collection.playlist_filters import PlaylistFilter
 from djtools.collection.playlists import Playlist, RekordboxPlaylist
 from djtools.collection.tracks import Track
 from djtools.utils.helpers import make_path
@@ -47,11 +47,6 @@ def copy_file(track: Track, destination: Path):
 #       use e.g. "rekordbox"
 #   - build_tag_playlists: builds collection playlists using "tags" component
 #       of the PlaylistConfig
-#   - PlaylistFilter: abstraction for filtering Tracks from Playlists
-#   - HipHopFilter: used to distinguish between actual hip hop tracks and bass
-#       tracks that have hip hop influences
-#   - MinimalDeepTechFilter: used to distinguish between minimal deep tech
-#       tracks with predominately house and techno influences
 #   - filter_tag_playlists: applies PlaylistFilter implementations to built tag
 #       playlists
 #   - aggregate_playlists: aggregates tracks from playlists in folders to
@@ -178,145 +173,6 @@ def build_tag_playlists(
         return None
 
     return playlist_class.new_playlist(name=content, tracks=tracks_with_tag)
-
-
-class PlaylistFilter(ABC):
-    "This class defines an interface for filtering tracks from playlists."
-
-    @abstractmethod
-    def filter_track(self, track: Track) -> bool:
-        """Returns True if this track should remain in the playlist.
-
-        Args:
-            track: Track object to apply filter to.
-
-        Returns:
-            Whether or not this track should be included in the playlist.
-        """
-
-    @abstractmethod
-    def is_filter_playlist(self, playlist: Playlist) -> bool:
-        """Returns True if this playlist should be filtered.
-
-        Args:
-            playlist: Playlist object to potentially filter.
-
-        Returns:
-            Whether or not to filter this playlist.
-        """
-
-
-class HipHopFilter(PlaylistFilter):
-    'This class filters playlists called "Hip Hop".'
-
-    def filter_track(self, track: Track) -> bool:
-        """Returns True if this track should remain in the playlist.
-
-        If the playlist is not underneath a folder called "Bass", then this
-        track is filtered out unless it has exclusively "Hip Hop" and "R&B"
-        genre tags. If the playlist is underneath a folder called "Bass", then
-        this track is filtered out if it does have exclusively "Hip Hop" and
-        "R&B" genre tags.
-
-        Args:
-            track: Track object to apply filter to.
-
-        Returns:
-            Whether or not this track should be included in the playlist.
-        """
-        pure_hip_hop_with_other_tags = not self._bass_hip_hop and any(
-            "r&b" not in x.lower() and "hip hop" not in x.lower()
-            for x in track.get_genre_tags()
-        )
-        bass_hip_hop_without_other_tags = self._bass_hip_hop and all(
-            "r&b" in x.lower() or "hip hop" in x.lower()
-            for x in track.get_genre_tags()
-        )
-        if pure_hip_hop_with_other_tags or bass_hip_hop_without_other_tags:
-            return False
-
-        return True
-
-
-    def is_filter_playlist(self, playlist: Playlist) -> bool:
-        """Returns True if this playlist's name is "Hip Hop".
-
-        Args:
-            playlist: Playlist object to potentially filter.
-
-        Returns:
-            Whether or not to filter this playlist.
-        """
-        if not playlist.get_name() == "Hip Hop":
-            return False
-
-        self._bass_hip_hop = False  #pylint: disable=attribute-defined-outside-init
-        parent = playlist.get_parent()
-        while parent:
-            if parent.get_name() == "Bass":
-                self._bass_hip_hop = True  #pylint: disable=attribute-defined-outside-init
-            parent = parent.get_parent()
-
-        return True
-
-
-class MinimalDeepTechFilter(PlaylistFilter):
-    'This class filters playlists called "Minimal Deep Tech".'
-
-    def filter_track(self, track: Track) -> bool:
-        """Returns True if this track should remain in the playlist.
-
-        If the playlist is not underneath a folder called "Techno", then this
-        track is filtered out if the genre tag preceding "Minimal Deep Tech" is
-        "Techno". If the playlist is underneath a folder called "Techno", then
-        this track is filtered out if the genre tag preceding
-        "Minimal Deep Tech" is not "Techno".
-
-        Args:
-            track: Track object to apply filter to.
-
-        Returns:
-            Whether or not this track should be included in the playlist.
-        """
-        house_exp = re.compile(r".*house.*")
-        techno_exp = re.compile(r".*techno.*")
-        house_tag = techno_tag = False
-        for tag in track.get_genre_tags():
-            if re.search(house_exp, tag.lower()):
-                house_tag = True
-            if re.search(techno_exp, tag.lower()):
-                techno_tag = True
-        if (
-            (self._techno and not techno_tag) or
-            (self._house and not house_tag)
-        ):
-            return False
-
-        return True
-
-    def is_filter_playlist(self, playlist: Playlist) -> bool:
-        """Returns True if this playlist's name is "Minimal Deep Tech".
-
-        Args:
-            playlist: Playlist object to potentially filter.
-
-        Returns:
-            Whether or not to filter this playlist.
-        """
-        if not playlist.get_name() == "Minimal Deep Tech":
-            return False
-
-        self._techno = False  #pylint: disable=attribute-defined-outside-init
-        self._house = False  #pylint: disable=attribute-defined-outside-init
-        parent = playlist.get_parent()
-        while parent:
-            if parent.get_name() == "Techno":
-                self._techno = True  #pylint: disable=attribute-defined-outside-init
-            if parent.get_name() == "House":
-                self._house = True  #pylint: disable=attribute-defined-outside-init
-            parent = parent.get_parent()
-
-        return True
 
 
 def filter_tag_playlists(

--- a/djtools/collection/playlist_builder.py
+++ b/djtools/collection/playlist_builder.py
@@ -7,7 +7,6 @@ from typing import Optional
 import yaml
 
 from djtools.collection.config import PlaylistConfig, PlaylistConfigContent
-from djtools.collection import helpers
 from djtools.collection.helpers import (
     add_selectors_to_tags,
     aggregate_playlists,
@@ -17,6 +16,7 @@ from djtools.collection.helpers import (
     PLATFORM_REGISTRY,
     print_playlists_tag_statistics,
 )
+from djtools.collection import playlist_filters
 from djtools.configs.config import BaseConfig
 from djtools.utils.helpers import make_path
 
@@ -131,7 +131,7 @@ def collection_playlists(
         filter_tag_playlists(
             tag_playlists,
             [
-                getattr(helpers, playlist_filter)()
+                getattr(playlist_filters, playlist_filter)()
                 for playlist_filter in config.COLLECTION_PLAYLIST_FILTERS
             ]
         )

--- a/djtools/collection/playlist_filters.py
+++ b/djtools/collection/playlist_filters.py
@@ -1,0 +1,156 @@
+"""This module contains the PlaylistFilter abstract base class and its\
+implementations.
+
+PlaylistFilter subclasses implement an 'is_filter_playlist' method and a
+'filter_track' method.
+
+The 'is_filter_playlist' method, when given a 'Playlist', returns true if that
+'Playlist' should have its tracks filtered.
+
+The 'filter_track' method, when given a 'Track', returns true if that 'Track'
+should remain in the playlist.
+"""
+from abc import ABC, abstractmethod
+import re
+
+from djtools.collection.playlists import Playlist
+from djtools.collection.tracks import Track
+
+
+class PlaylistFilter(ABC):
+    "This class defines an interface for filtering tracks from playlists."
+
+    @abstractmethod
+    def filter_track(self, track: Track) -> bool:
+        """Returns True if this track should remain in the playlist.
+
+        Args:
+            track: Track object to apply filter to.
+
+        Returns:
+            Whether or not this track should be included in the playlist.
+        """
+
+    @abstractmethod
+    def is_filter_playlist(self, playlist: Playlist) -> bool:
+        """Returns True if this playlist should be filtered.
+
+        Args:
+            playlist: Playlist object to potentially filter.
+
+        Returns:
+            Whether or not to filter this playlist.
+        """
+
+
+class HipHopFilter(PlaylistFilter):
+    'This class filters playlists called "Hip Hop".'
+
+    def filter_track(self, track: Track) -> bool:
+        """Returns True if this track should remain in the playlist.
+
+        If the playlist is not underneath a folder called "Bass", then this
+        track is filtered out unless it has exclusively "Hip Hop" and "R&B"
+        genre tags. If the playlist is underneath a folder called "Bass", then
+        this track is filtered out if it does have exclusively "Hip Hop" and
+        "R&B" genre tags.
+
+        Args:
+            track: Track object to apply filter to.
+
+        Returns:
+            Whether or not this track should be included in the playlist.
+        """
+        pure_hip_hop_with_other_tags = not self._bass_hip_hop and any(
+            "r&b" not in x.lower() and "hip hop" not in x.lower()
+            for x in track.get_genre_tags()
+        )
+        bass_hip_hop_without_other_tags = self._bass_hip_hop and all(
+            "r&b" in x.lower() or "hip hop" in x.lower()
+            for x in track.get_genre_tags()
+        )
+        if pure_hip_hop_with_other_tags or bass_hip_hop_without_other_tags:
+            return False
+
+        return True
+
+
+    def is_filter_playlist(self, playlist: Playlist) -> bool:
+        """Returns True if this playlist's name is "Hip Hop".
+
+        Args:
+            playlist: Playlist object to potentially filter.
+
+        Returns:
+            Whether or not to filter this playlist.
+        """
+        if not playlist.get_name() == "Hip Hop":
+            return False
+
+        self._bass_hip_hop = False  #pylint: disable=attribute-defined-outside-init
+        parent = playlist.get_parent()
+        while parent:
+            if parent.get_name() == "Bass":
+                self._bass_hip_hop = True  #pylint: disable=attribute-defined-outside-init
+            parent = parent.get_parent()
+
+        return True
+
+
+class MinimalDeepTechFilter(PlaylistFilter):
+    'This class filters playlists called "Minimal Deep Tech".'
+
+    def filter_track(self, track: Track) -> bool:
+        """Returns True if this track should remain in the playlist.
+
+        If the playlist is not underneath a folder called "Techno", then this
+        track is filtered out if the genre tag preceding "Minimal Deep Tech" is
+        "Techno". If the playlist is underneath a folder called "Techno", then
+        this track is filtered out if the genre tag preceding
+        "Minimal Deep Tech" is not "Techno".
+
+        Args:
+            track: Track object to apply filter to.
+
+        Returns:
+            Whether or not this track should be included in the playlist.
+        """
+        house_exp = re.compile(r".*house.*")
+        techno_exp = re.compile(r".*techno.*")
+        house_tag = techno_tag = False
+        for tag in track.get_genre_tags():
+            if re.search(house_exp, tag.lower()):
+                house_tag = True
+            if re.search(techno_exp, tag.lower()):
+                techno_tag = True
+        if (
+            (self._techno and not techno_tag) or
+            (self._house and not house_tag)
+        ):
+            return False
+
+        return True
+
+    def is_filter_playlist(self, playlist: Playlist) -> bool:
+        """Returns True if this playlist's name is "Minimal Deep Tech".
+
+        Args:
+            playlist: Playlist object to potentially filter.
+
+        Returns:
+            Whether or not to filter this playlist.
+        """
+        if not playlist.get_name() == "Minimal Deep Tech":
+            return False
+
+        self._techno = False  #pylint: disable=attribute-defined-outside-init
+        self._house = False  #pylint: disable=attribute-defined-outside-init
+        parent = playlist.get_parent()
+        while parent:
+            if parent.get_name() == "Techno":
+                self._techno = True  #pylint: disable=attribute-defined-outside-init
+            if parent.get_name() == "House":
+                self._house = True  #pylint: disable=attribute-defined-outside-init
+            parent = parent.get_parent()
+
+        return True

--- a/docs/tutorials/developer_docs/collections_api.md
+++ b/docs/tutorials/developer_docs/collections_api.md
@@ -1,0 +1,79 @@
+# Using the Collections API
+
+
+Interacting with your collection is easy using the API provided by implementations of `Collection`, `Track`, and `Playlist`.
+For a complete description of the methods these classes provide, please see the [references](../../reference/collection/index.md).
+What follows is more of a list of examples to demonstrate how quick and useful interactive collection manipulations can be. 
+
+To load a collection, instantiate the class associated with format of the serialized collection passed as a parameter:
+
+```
+collection = RekordboxCollection("/path/to/rekordbox.xml")
+```
+
+After you're done working with your collection, you can serialize it back into a format that you can perhaps import from or use as input to other scripts:
+
+```
+output_xml = collection.serialize("test_rekordbox.xml")
+```
+
+---
+
+Once deserialized, you can manipulate the tracks and playlists in your collection in a variety of ways.
+
+For example, you can filter tracks to create new playlists.
+
+This snippet creates a new playlist that has all the tracks in your collection containing non-integer BPM values which is an indicator of potentially incorrect beat grids:
+```
+collection.add_playlist(
+    RekordboxPlaylist.new_playlist(
+        "Non-integer BPMs",
+        tracks={k: v for k, v in collection.get_tracks().items() if not v.get_bpm().is_integer()}
+    )
+)
+```
+
+This snippet builds a playlist where the average BPM reported as an attribute of a track doesn't match the average of the multiple BPM values in its beat grid. This can happen if you do a bulk edit of the BPM values of your tracks without updating their beat grids.
+
+```
+collection.add_playlist(
+    RekordboxPlaylist.new_playlist(
+        "Goofy BPMs",
+        tracks={
+            k: v for k, v in collection.get_tracks().items()
+            if v.get_bpm().is_integer() and
+            len(v._beat_grid) > 0 and
+            abs(sum([float(x["Bpm"]) for x in v._beat_grid]) / len(v._beat_grid) - v.get_bpm()) > 1
+        }
+    )
+)
+```
+
+This snippet will identify all the tracks in your collection that are a WAV file:
+
+```
+collection.add_playlist(
+    RekordboxPlaylist.new_playlist(
+        "wavs",
+        tracks={
+            k: v for k, v in collection.get_tracks().items()
+            if str(v.get_location()).endswith(".wav")
+        }
+    )
+)
+```
+
+---
+
+Apart from adding playlists, you can also overwrite the tracks in the collection to create new collections with different tracks.
+
+For example, you may have a script that operates on input collections and you want to ensure that only techno tracks are operated upon. To do this you might have your collection only contain tracks where the word "techno" appears in their path:
+
+```
+collection.set_tracks(
+    tracks={
+        track_id: track for track_id, track in collection.get_tracks().items()
+        if "techno" in str(track.get_location().parent).lower()
+    }
+)
+```

--- a/docs/tutorials/developer_docs/index.md
+++ b/docs/tutorials/developer_docs/index.md
@@ -1,0 +1,6 @@
+# Developer Documentation
+
+* [System Overview](system_overview.md)
+* [Adding DJ Software Support to the Collections Package](new_collections.md)
+* [Using the Collections API](collections_api.md)
+* [Adding Custom PlaylistFilters](playlist_filters.md)

--- a/docs/tutorials/developer_docs/new_collections.md
+++ b/docs/tutorials/developer_docs/new_collections.md
@@ -1,0 +1,197 @@
+# Adding DJ Software Support to the Collections Package
+
+
+## Contents
+- [Overview](#overview)
+- [Collections](#collections)
+- [Tracks](#tracks)
+- [Playlists](#playlists)
+- [Appendix: Rekordbox as an example](#rekordbox-as-an-example)
+    - [RekordboxCollection](#rekordboxcollection)
+    - [RekordboxTrack](#rekordboxtrack)
+    - [RekordboxPlaylist](#rekordboxplaylist)
+
+
+## Overview
+The `collection` package is designed to work with any serialized DJ collection that contains all the information about tracks and playlists.
+Each of these three components, `Collection`, `Playlist`, and `Track`, has an interface with which `djtools` uses to implement [these features](../../how_to_guides/index.md#collection).
+
+In order to extend `djtools` so that these features can be used for other DJ platforms (Denon, Serato, Traktor, Virtual DJ, etc.), these three components must be subclassed to implement several abstract methods. 
+
+
+## Collections
+Every `Collection` subclass must implement an `__init__` that accepts a `pathlib.Path` (and also `str` if you decorate it with `@make_path`).
+The `__init__` must deserialize the `Track` and `Playlist` data under the `Path` to create a `Collection` object.
+
+::: djtools.collection.collections.Collection.__init__
+    options:
+        show_docstring_description: false
+        show_docstring_parameters: false
+        show_docstring_returns: false
+
+The other method a `Collection` must implement is `serialize` which will write the `Collection` data in whatever format is native for that DJ platform and return the `Path` to it.
+
+::: djtools.collection.collections.Collection.serialize
+    options:
+        show_docstring_description: false
+        show_docstring_parameters: false
+        show_docstring_returns: false
+
+---
+
+Subclasses of `Collection` inherit a few methods necessary to execute on the `djtools` feature set:
+
+###### Appending a `Playlist` object to the root `Playlist`:
+::: djtools.collection.collections.Collection.add_playlist
+    options:
+        show_docstring_description: false
+        show_docstring_parameters: false
+###### Getting the root `Playlist` or, if a `name` is provided, the list of `Playlist` objects with matching names (supports fuzzy matching with the `glob` parameter):
+::: djtools.collection.collections.Collection.get_playlists
+    options:
+        show_docstring_description: false
+        show_docstring_parameters: false
+        show_docstring_returns: false
+###### Getting the dictionary mapping track IDs to `Track` objects:
+::: djtools.collection.collections.Collection.get_tracks
+    options:
+        show_docstring_description: false
+        show_docstring_returns: false
+###### Set the dictionary mapping track IDs to `Track` objects:
+::: djtools.collection.collections.Collection.set_tracks
+    options:
+        show_docstring_description: false
+        show_docstring_parameters: false
+###### Get a dictionary with the sorted set of genre tags and non-genre tags:
+::: djtools.collection.collections.Collection.get_all_tags
+    options:
+        show_docstring_description: false
+        show_docstring_returns: false
+
+
+## Tracks
+Subclasses of the `Track` class have 16 abstract methods to be implemented, but 14 of those methods are simple getters or setters.
+The two primary abstract methods are, again, `__init__` and `serialize`.
+
+The requirements for a `Track` subclass' initialization are only that it parses from the input object the dozen or so attributes that the other abstract methods either get or set:
+
+::: djtools.collection.tracks.Track.__init__
+    options:
+        show_docstring_description: false
+
+A `Track` subclass must implement a `serialize` which returns an exact match of the input object used with `__init__`. In other words, it must be the case that `input == Track(input).serialize()`:
+
+::: djtools.collection.tracks.Track.serialize
+    options:
+        show_docstring_description: false
+        show_docstring_returns: false
+
+Let's not enumerate the many getter and setters of the `Track` object here, but you can check them out for yourself:
+
+::: djtools.collection.tracks.Track
+    options:
+        show_bases: false
+        members: false
+        show_docstring_description: false
+
+
+## Playlists 
+A subclass of the `Playlist` class must implement five abstract methods for working with a recursive playlist structure.
+Like the other components of a collection, the `Playlist` class also requires an `__init__` and `serialize` implementation.
+
+The `__init__` method must take an input that's either a playlist folder or a playlist that contains tracks:
+
+::: djtools.collection.playlists.Playlist.__init__
+    options:
+        show_docstring_description: false
+
+As with `Track`, `Playlist` subclasses must implement a `serialize` which returns an exact match of the input object used with `__init__`. In other words, it must be the case that `input == Playlist(input).serialize()`:
+
+---
+
+The other abstract methods that must be implemented are:
+
+The `get_name` and the `is_folder` methods which are a simple getter and condition check, so they won't be shown here.
+
+A class method called `new_playlist` which can create a `Playlist` object from either a list of `Playlist` objects or a dictionary of `Track` objects:
+
+::: djtools.collection.playlists.Playlist.new_playlist
+    options:
+        show_docstring_description: false
+        show_docstring_parameters: false
+        show_docstring_raises: false
+        show_docstring_returns: false
+
+
+## Appendix
+
+
+### Rekordbox as an example
+
+
+#### RekordboxCollection
+Rekordbox supports exporting a collection to an XML file which contains two primary sections: a COLLECTION tag with TRACK tags, and a PLAYLISTS tag with NODE tags with either more NODE tags or TRACK tags that have a key referencing the COLLECTION TRACKS. A [minimal example XML](https://github.com/a-rich/DJ-Tools/blob/main/testing/data/rekordbox.xml) can be seen in the test data.
+
+The `RekordboxCollection` implements `__init__` by parsing the XML with BeautifulSoup, deserializing the tracks as a dictionary of `RekordboxTrack` objects, and deserializing the playlists into the root node of a `RekordboxPlaylist` tree:
+
+::: djtools.collection.collections.RekordboxCollection.__init__
+    options:
+        show_docstring_description: false
+        show_docstring_parameters: false
+
+The `serialize` method of `RekordboxCollection` builds a new XML document, populates the COLLECTION tag by serializing the values of the `RekordboxTrack` dictionary, and then populates the PLAYLISTS tag by iterating the root `RekordboxPlaylist` and serializing its children:
+
+::: djtools.collection.collections.RekordboxCollection.serialize
+    options:
+        show_docstring_description: false
+        show_docstring_parameters: false
+        show_docstring_returns: false
+
+
+#### RekordboxTrack
+A track in an XML contains all the information about tracks except for what playlists they belong to. This information is stored directly in the attributes of the TRACK tag with the exception of the beat grid and hot cue data which are represented as sub-tags TEMPO and POSITION_MARK, respectively.
+
+The `RekordboxTrack` implements `__init__` by enumerating the attributes of the input Track tag and deserializing the string values as types that are more useful in Python, such as `datetime` objects, `lists`, `sets`, and numerical values:
+
+::: djtools.collection.tracks.RekordboxTrack.__init__
+    options:
+        show_docstring_description: false
+        show_docstring_parameters: false
+
+The `serialize` method of `RekordboxTrack` builds a new XML tag for a TRACK and populates the attributes of that tag using the `RekordboxTrack` members. Because Rekordbox serializes TRACK tags inside of the PLAYLISTS differently, this method accepts a parameter to indicate that the `RekordboxTrack` should serialize containing only its ID:
+
+::: djtools.collection.tracks.RekordboxTrack.serialize
+    options:
+        show_docstring_description: false
+        show_docstring_parameters: false
+        show_docstring_raises: false
+        show_docstring_returns: false
+
+
+#### RekordboxPlaylist
+A playlist in an XML is a NODE tag which is a recursive structure that contains other NODE tags. The leaves of this tree are NODE tags which contain only TRACK tags with just a single attribute, KEY, which maps to the trackID attribute of the TRACK tags under the COLLECTION tag.
+
+NODE tags also have attributes for the Name and Type (folder or not) and either a Count or an Entries attribute which has the number of playlists or number of tracks, respectively.
+
+The `__init__` method deserializes a NODE tag by either recursively deserializing its children NODE tags (if it's a folder) or else creating a dictionary of tracks from `RekordboxCollection` object's tracks passed as a parameter:
+
+::: djtools.collection.playlists.RekordboxPlaylist.__init__
+    options:
+        show_docstring_description: false
+        show_docstring_parameters: false
+
+The `new_playlist` method creates a new Node tag and deserializes it as a `RekordboxPlaylist` before setting its members with either a `RekordboxTrack` dictionary or a list of `RekordboxPlaylist` objects:
+
+::: djtools.collection.playlists.RekordboxPlaylist.new_playlist
+    options:
+        show_docstring_description: false
+        show_docstring_parameters: false
+        show_docstring_raises: false
+        show_docstring_returns: false
+    
+The `serialize` method of `RekordboxPlaylist` builds a new XML tag for a NODE and populates the attributes and sub-tags recursively:
+
+::: djtools.collection.playlists.RekordboxPlaylist.serialize
+    options:
+        show_docstring_description: false
+        show_docstring_returns: false

--- a/docs/tutorials/developer_docs/playlist_filters.md
+++ b/docs/tutorials/developer_docs/playlist_filters.md
@@ -1,0 +1,57 @@
+# PlaylistFilters
+
+When creating tag playlists, the `playlist_builder` calls `filter_tag_playlists` with a configurable list of `PlaylistFilter` implementations:
+
+::: djtools.collection.helpers.filter_tag_playlists
+    options:
+        show_docstring_description: false
+        show_docstring_parameters: false
+        show_docstring_returns: false
+
+These `PlaylistFilters` inject custom behavior into the `playlist_builder`. In general, this is done by scanning through a playlist structure and looking for a playlist, or playlists, that match one description and then filter for tracks that match another description.
+
+::: djtools.collection.playlist_filters.PlaylistFilter
+    options:
+        show_bases: false
+        members: false
+        show_docstring_description: false
+
+`PlaylistFilter` subclasses must implement two methods:
+
+- `is_filter_playlist`: returns True if a given `Playlist` should have the filter applied to its tracks
+- `filter_track`: returns True if a track should remain in the playlist after applying the filter.
+
+Once a `PlaylistFilter` is implemented, it must be added to the list of supported `COLLECTION_PLAYLIST_FILTERS`:
+
+::: djtools.collection.config.CollectionConfig
+    options:
+        show_bases: false
+        members: false
+        show_docstring_description: false
+
+
+## PlaylistFilter Implementations
+
+The `playlist_filters` module contains a set of `PlaylistFilter` implementations including `HipHopFilter` and `MinimalDeepTechFilter`.
+
+### HipHopFilter
+- Checks to see if a playlist named 'Hip Hop' is a child of a playlist named 'Bass'
+- If it is, then tracks in that playlist must have a genre tag besides 'Hip Hop' and 'R&B'
+- If it is not, then tracks in that playlist must have only genre tags 'Hip Hop' and 'R&G'
+
+::: djtools.collection.playlist_filters.HipHopFilter
+    options:
+        show_bases: false
+        members: false
+        show_docstring_description: false
+
+### MinimalDeepTechFilter
+- Checks to see if a playlist named 'Minimal Deep Tech' is a child of a playlist named 'Techno' or 'House'
+- If it's a child of a 'Techno' playlist, then at least one other genre tag must contain the substring 'techno' (case insensitive)
+- If it's a child of a 'House' playlist, then at least one other genre tag must contain the substring 'house'
+
+::: djtools.collection.playlist_filters.MinimalDeepTechFilter
+    options:
+        show_bases: false
+        members: false
+        show_docstring_description: false

--- a/docs/tutorials/developer_docs/system_overview.md
+++ b/docs/tutorials/developer_docs/system_overview.md
@@ -1,0 +1,15 @@
+# System Overview
+
+`djtools` is a set of packages which, together, provide functional interfaces to streamline a multitude collection curation tasks.
+
+Although there are parts of `djtools`, like the collection package, that are designed to [operate interactively](./collections_api.md), `djtools` is primarily intended to be used as a CLI.
+
+When executed, the [main function](https://github.com/a-rich/DJ-Tools/blob/main/djtools/__init__.py) of `djtools` builds 
+a configuration, iterates through the top-level operations exposed by each package, and executes those operations as determined by the configuration.
+
+When building the configuration, `djtools` first looks for a [config.yaml](https://github.com/a-rich/DJ-Tools/blob/main/djtools/configs/config.yaml) in the configs folder from which to load the configuration objects.
+If no config file is found, default values defined in the Pydantic models are used.
+If CLI arguments are provided, they override the corresponding configuration options.
+
+The top-level operation exposed by the different `djtools` packages all accept a `BaseConfig` object which is returned from the `build_config` function.
+In short, the `BaseConfig` defines some options common to all packages and has all the package-specific `Config` objects merged into it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,12 @@ nav:
       - Setup: tutorials/getting_started/setup.md
       - Usage: tutorials/getting_started/usage.md
       - Configuration: tutorials/getting_started/configuration.md
+    - Developer Docs:
+      - Home: tutorials/developer_docs/index.md
+      - System Overview: tutorials/developer_docs/system_overview.md
+      - Adding DJ Software Support to the Collections Package: tutorials/developer_docs/new_collections.md
+      - Using the Collections API: tutorials/developer_docs/collections_api.md
+      - Adding Custom PlaylistFilters: tutorials/developer_docs/playlist_filters.md
   - How-to Guides:
     - Home: how_to_guides/index.md
     - Collection:

--- a/testing/collection/test_helpers.py
+++ b/testing/collection/test_helpers.py
@@ -13,8 +13,6 @@ from djtools.collection.helpers import (
     # aggregate_playlists,
     build_combiner_playlists,
     build_tag_playlists,
-    HipHopFilter,
-    MinimalDeepTechFilter,
     parse_numerical_selectors,
     parse_string_selectors,
     PLATFORM_REGISTRY,
@@ -23,7 +21,6 @@ from djtools.collection.helpers import (
     scale_data,
 )
 from djtools.collection.playlists import Playlist
-from djtools.collection.tracks import RekordboxTrack
 
 
 # pylint: disable=duplicate-code
@@ -127,52 +124,8 @@ def test_copy_file(tmpdir, rekordbox_track):
     assert new_file_path.exists()
 
 
-@pytest.mark.parametrize(
-    "bass_hip_hop,genre_tags,expected",
-    [
-        (True, ["Hip Hop", "R&B"], False),
-        (True, ["Hip Hop", "Trap"], True),
-        (False, ["Hip Hop", "R&B"], True),
-        (False, ["Hip Hop", "Trap"], False),
-    ],
-)
-def test_hiphopfilter(bass_hip_hop, genre_tags, expected, rekordbox_track):
-    """Test for the HipHopFilter class."""
-    track_filter = HipHopFilter()
-    with mock.patch.object(
-        track_filter, '_bass_hip_hop', bass_hip_hop, create=True
-    ), mock.patch.object(
-        RekordboxTrack, "get_genre_tags", lambda x: genre_tags
-    ):
-        result = track_filter.filter_track(rekordbox_track)
-        assert result == expected
-
-
 def test_filter_tag_playlists():
     """Test the filter_tag_playlists function."""
-
-
-@pytest.mark.parametrize(
-    "techno,genre_tags,expected",
-    [
-        (True, ["Techno", "Minimal Deep Tech"], True),
-        (True, ["House", "Minimal Deep Tech"], False),
-        (False, ["Techno", "Minimal Deep Tech"], False),
-        (False, ["House", "Minimal Deep Tech"], True),
-    ],
-)
-def test_minimaldeeptechfilter(techno, genre_tags, expected, rekordbox_track):
-    """Test for the HipHopFilter class."""
-    track_filter = MinimalDeepTechFilter()
-    with mock.patch.object(
-        track_filter, '_techno', techno, create=True
-    ), mock.patch.object(
-        track_filter, '_house', not techno, create=True
-    ), mock.patch.object(
-        RekordboxTrack, "get_genre_tags", lambda x: genre_tags
-    ):
-        result = track_filter.filter_track(rekordbox_track)
-        assert result == expected
 
 
 def test_parse_numerical_selectors():

--- a/testing/collection/test_playlist_filters.py
+++ b/testing/collection/test_playlist_filters.py
@@ -1,0 +1,53 @@
+"""Testing for the playlist_filters module."""
+from unittest import mock
+
+import pytest
+
+from djtools.collection.playlist_filters import (
+    HipHopFilter, MinimalDeepTechFilter
+)
+from djtools.collection.tracks import RekordboxTrack
+
+
+@pytest.mark.parametrize(
+    "bass_hip_hop,genre_tags,expected",
+    [
+        (True, ["Hip Hop", "R&B"], False),
+        (True, ["Hip Hop", "Trap"], True),
+        (False, ["Hip Hop", "R&B"], True),
+        (False, ["Hip Hop", "Trap"], False),
+    ],
+)
+def test_hiphopfilter(bass_hip_hop, genre_tags, expected, rekordbox_track):
+    """Test for the HipHopFilter class."""
+    track_filter = HipHopFilter()
+    with mock.patch.object(
+        track_filter, '_bass_hip_hop', bass_hip_hop, create=True
+    ), mock.patch.object(
+        RekordboxTrack, "get_genre_tags", lambda x: genre_tags
+    ):
+        result = track_filter.filter_track(rekordbox_track)
+        assert result == expected
+
+
+@pytest.mark.parametrize(
+    "techno,genre_tags,expected",
+    [
+        (True, ["Techno", "Minimal Deep Tech"], True),
+        (True, ["House", "Minimal Deep Tech"], False),
+        (False, ["Techno", "Minimal Deep Tech"], False),
+        (False, ["House", "Minimal Deep Tech"], True),
+    ],
+)
+def test_minimaldeeptechfilter(techno, genre_tags, expected, rekordbox_track):
+    """Test for the HipHopFilter class."""
+    track_filter = MinimalDeepTechFilter()
+    with mock.patch.object(
+        track_filter, '_techno', techno, create=True
+    ), mock.patch.object(
+        track_filter, '_house', not techno, create=True
+    ), mock.patch.object(
+        RekordboxTrack, "get_genre_tags", lambda x: genre_tags
+    ):
+        result = track_filter.filter_track(rekordbox_track)
+        assert result == expected


### PR DESCRIPTION
Why?
Explanation about what aspects of djtools are extensible is necessary for developers to contribute.

What?
Separate PlaylistFilters into their own module. Add several docs for developers.