### PR TITLE
refactor: cleanup the exported members

### DIFF
--- a/djtools/__init__.py
+++ b/djtools/__init__.py
@@ -10,55 +10,55 @@ is uploaded to the Beatcloud.
 """
 from .configs import build_config
 from .collection import (
-    COLLECTION_OPERATIONS,
     collection_playlists,
     copy_playlists,
+    RekordboxCollection,
+    RekordboxPlaylist,
+    RekordboxTrack,
     shuffle_playlists,
 )
+from .collection.__init__ import COLLECTION_OPERATIONS
 from .spotify import (
     spotify_playlist_from_upload,
-    SPOTIFY_OPERATIONS,
     spotify_playlists,
 )
+from .spotify.__init__ import SPOTIFY_OPERATIONS
 from .sync import (
     download_collection,
     download_music,
-    SYNC_OPERATIONS,
     upload_collection,
-    upload_log,
     upload_music,
 )
+from .sync.__init__ import SYNC_OPERATIONS
+from .sync.helpers import upload_log
 from .utils import (
     compare_tracks,
-    initialize_logger,
     normalize,
-    process_recording,
-    UTILS_OPERATIONS,
+    process,
     url_download,
 )
+from .utils.__init__ import UTILS_OPERATIONS
+from .utils.helpers import initialize_logger
 from .version import __version__
 
 
 __all__ = (
     "build_config",
-    "COLLECTION_OPERATIONS",
     "collection_playlists",
     "compare_tracks",
     "copy_playlists",
     "download_collection",
     "download_music",
-    "initialize_logger",
     "normalize",
-    "process_recording",
+    "process",
+    "RekordboxCollection",
+    "RekordboxPlaylist",
+    "RekordboxTrack",
     "shuffle_playlists",
     "spotify_playlist_from_upload",
     "spotify_playlists",
-    "SPOTIFY_OPERATIONS",
-    "SYNC_OPERATIONS",
-    "upload_log",
     "upload_collection",
     "upload_music",
-    "UTILS_OPERATIONS",
     "url_download",
 )
 

--- a/djtools/collection/__init__.py
+++ b/djtools/collection/__init__.py
@@ -15,10 +15,12 @@
     * `tracks`: abstractions and implementations for tracks
 """
 
-from djtools.collection.config import CollectionConfig
+from djtools.collection.collections import RekordboxCollection
 from djtools.collection.copy_playlists import copy_playlists
 from djtools.collection.playlist_builder import collection_playlists
+from djtools.collection.playlists import RekordboxPlaylist
 from djtools.collection.shuffle_playlists import shuffle_playlists
+from djtools.collection.tracks import RekordboxTrack
 
 
 COLLECTION_OPERATIONS = {
@@ -30,8 +32,9 @@ COLLECTION_OPERATIONS = {
 
 __all__ = (
     "collection_playlists",
-    "CollectionConfig",
     "copy_playlists",
+    "RekordboxCollection",
+    "RekordboxPlaylist",
+    "RekordboxTrack",
     "shuffle_playlists",
-    "COLLECTION_OPERATIONS",
 )

--- a/djtools/spotify/__init__.py
+++ b/djtools/spotify/__init__.py
@@ -4,7 +4,6 @@
     * `playlist_builder`: constructs or updates Spotify playlists using either
         Subreddit posts or the Discord webhook output from `UPLOAD_MUSIC`
 """
-from djtools.spotify.config import SpotifyConfig
 from djtools.spotify.playlist_builder import (
     spotify_playlist_from_upload, spotify_playlists
 )
@@ -18,7 +17,5 @@ SPOTIFY_OPERATIONS = {
 
 __all__ = (
     "spotify_playlist_from_upload",
-    "SpotifyConfig",
-    "SPOTIFY_OPERATIONS",
     "spotify_playlists",
 )

--- a/djtools/sync/__init__.py
+++ b/djtools/sync/__init__.py
@@ -4,7 +4,6 @@
     * `sync_operations`: for syncing audio and collection files to the
         Beatcloud
 """
-from djtools.sync.config import SyncConfig
 from djtools.sync.helpers import upload_log
 from djtools.sync.sync_operations import (
     download_collection, download_music, upload_collection, upload_music
@@ -22,9 +21,6 @@ SYNC_OPERATIONS = {
 __all__ = (
     "download_collection",
     "download_music",
-    "SyncConfig",
-    "SYNC_OPERATIONS",
     "upload_collection",
-    "upload_log",
     "upload_music",
 )

--- a/djtools/utils/__init__.py
+++ b/djtools/utils/__init__.py
@@ -12,7 +12,6 @@
         bit rate and file format.
     * `url_download`: download tracks from a URL (e.g. Soundcloud playlist).
 """
-from djtools.utils.config import UtilsConfig
 from djtools.utils.check_tracks import compare_tracks
 from djtools.utils.normalize_audio import normalize
 from djtools.utils.process_recording import process
@@ -29,10 +28,7 @@ UTILS_OPERATIONS = {
 
 __all__ = (
     "compare_tracks",
-    "initialize_logger",
     "normalize",
     "process",
     "url_download",
-    "UtilsConfig",
-    "UTILS_OPERATIONS",
 )


### PR DESCRIPTION
Why?
Irrelevant methods shouldn't be exported. It clutters the screen when working with djtools interactively or as a library.

What?
Don't export the *_OPERATONS dictionaries, upload_log, or initialize_logger.