### PR TITLE
refactor: show full BaseConfig

### DIFF
--- a/djtools/__init__.py
+++ b/djtools/__init__.py
@@ -10,6 +10,7 @@ is uploaded to the Beatcloud.
 """
 from .configs import build_config
 from .collection import (
+    COLLECTION_OPERATIONS,
     collection_playlists,
     copy_playlists,
     RekordboxCollection,
@@ -17,27 +18,26 @@ from .collection import (
     RekordboxTrack,
     shuffle_playlists,
 )
-from .collection.__init__ import COLLECTION_OPERATIONS
 from .spotify import (
+    SPOTIFY_OPERATIONS,
     spotify_playlist_from_upload,
     spotify_playlists,
 )
-from .spotify.__init__ import SPOTIFY_OPERATIONS
 from .sync import (
+    SYNC_OPERATIONS,
     download_collection,
     download_music,
     upload_collection,
     upload_music,
 )
-from .sync.__init__ import SYNC_OPERATIONS
 from .sync.helpers import upload_log
 from .utils import (
+    UTILS_OPERATIONS,
     compare_tracks,
     normalize,
     process,
     url_download,
 )
-from .utils.__init__ import UTILS_OPERATIONS
 from .utils.helpers import initialize_logger
 from .version import __version__
 

--- a/djtools/collection/__init__.py
+++ b/djtools/collection/__init__.py
@@ -9,6 +9,7 @@
     * `playlist_builder`: constructs playlists using tags in a Collection and a
         defined playlist structure in
         `collection_playlists.yaml`
+    * `playlist_filters`: abstractions and implementations for playlist filters
     * `playlists`: abstractions and implementations for playlists
     * `shuffle_playlists`: writes sequential numbers to tags of shuffled tracks
         in playlists to emulate playlist shuffling

--- a/djtools/configs/__init__.py
+++ b/djtools/configs/__init__.py
@@ -1,15 +1,14 @@
 """The `configs` package contains modules:
+    * `cli_args`: module for handling parsing command-line arguments
     * `config`: the base configuration object containing attributes for options
         which either do not apply to any package in particular or else apply to
         multiple packages
     * `helpers`: contains functions for building configuration objects and
         parsing command-line arguments
 """
-from djtools.configs.config import BaseConfig
 from djtools.configs.helpers import build_config
 
 
 __all__ = (
-    "BaseConfig",
     "build_config",
 )

--- a/djtools/configs/config.py
+++ b/djtools/configs/config.py
@@ -2,6 +2,7 @@
 this configuration object either don't apply to any particular package or they
 apply to multiple packages. The attributes of this configuration object
 correspond with the "configs" key of config.yaml."""
+import inspect
 import logging
 from typing_extensions import Literal
 
@@ -29,11 +30,24 @@ class BaseConfig(BaseModel, extra=Extra.allow):
     def __repr__(self):
         super_keys = set(BaseConfig.__fields__)
         ret = f"{self.__class__.__name__}("
+
+        # Inspect the stack to determine if the BaseConfig is being displayed
+        # as part of the CLI's execution or otherwise.
+        stack = inspect.stack()
+        entry_frame = stack[-1]
+        calling_frame = stack[2]
+        show_full_config = True
+        if (
+            entry_frame[1].endswith("main/bin/djtools") and
+            calling_frame[3] == "build_config"
+        ):
+            show_full_config = False
+
         for name, value in self.dict().items():
             if (
                 (name in super_keys and type(self) is not BaseConfig)  # pylint: disable=unidiomatic-typecheck
                 or (name not in super_keys and type(self) is BaseConfig)  # pylint: disable=unidiomatic-typecheck
-            ):
+            ) and not show_full_config:
                 continue
             if (
                 isinstance(value, list) and len(value) > 1

--- a/djtools/sync/__init__.py
+++ b/djtools/sync/__init__.py
@@ -4,7 +4,6 @@
     * `sync_operations`: for syncing audio and collection files to the
         Beatcloud
 """
-from djtools.sync.helpers import upload_log
 from djtools.sync.sync_operations import (
     download_collection, download_music, upload_collection, upload_music
 )

--- a/djtools/utils/__init__.py
+++ b/djtools/utils/__init__.py
@@ -15,7 +15,6 @@
 from djtools.utils.check_tracks import compare_tracks
 from djtools.utils.normalize_audio import normalize
 from djtools.utils.process_recording import process
-from djtools.utils.helpers import initialize_logger
 from djtools.utils.url_download import url_download
 
 


### PR DESCRIPTION
Why?
When displaying configs during CLI execution, it's desirable to show each package's config separately with the BaseConfig containing only the fields exclusive to it so as to reduce clutter and organize the output...

When displaying the BaseConfig in, for example, a Python shell, it's much more useful to show the entire config instead having to access directly the fields which you cannot see.

What?
Inspect the stack frame to infer whether build_config is running as part of the CLI's execution or not.