### PR TITLE
test: Cython peephole optimizer fix

### DIFF
--- a/src/djtools/sync/helpers.py
+++ b/src/djtools/sync/helpers.py
@@ -187,9 +187,11 @@ def upload_log(config: BaseConfig, log_file: Path):
     now = datetime.now()
     one_day = timedelta(days=1)
     for _file in log_file.parent.rglob("*"):
-        if _file.name == "__init__.py" or not _file.is_file():
-            continue
-        if _file.lstat().st_mtime < (now - one_day).timestamp():
+        if (
+            _file.name != "__init__.py"
+            and _file.is_file()
+            and _file.lstat().st_mtime < (now - one_day).timestamp()
+        ):
             _file.unlink()
 
 

--- a/tests/sync/test_helpers.py
+++ b/tests/sync/test_helpers.py
@@ -189,7 +189,7 @@ def test_upload_log(mock_popen, tmpdir, config):
     one_day_ago = now - timedelta(days=1)
     test_log = f'{now.strftime("%Y-%m-%d")}.log'
     filenames = [
-        "empty.txt",
+        "__init__.py",
         test_log,
         f'{one_day_ago.strftime("%Y-%m-%d")}.log',
     ]
@@ -197,7 +197,7 @@ def test_upload_log(mock_popen, tmpdir, config):
     for filename in filenames:
         file_path = Path(tmpdir) / filename
         with open(file_path, mode="w", encoding="utf-8") as _file:
-            _file.write("stuff")
+            _file.write("")
         if filename != test_log:
             os.utime(file_path, (ctime, ctime))
     process = mock_popen.return_value.__enter__.return_value


### PR DESCRIPTION
Why?
"continue" statement was being skipped during coverage.

What?
Refactor "continue" out of upload_log logic.