### PR TITLE
feat: override playlist names

### DIFF
--- a/docs/how_to_guides/collection_playlists.md
+++ b/docs/how_to_guides/collection_playlists.md
@@ -32,6 +32,15 @@ You can ignore the `combiner` part of the YAML for now. Although it's similar to
 
 The configuration above specifies a set of `name` folders with lists of playlists and / or folders inside of them. The leaves of this playlist tree are the actual playlists themselves named after the tag that the playlist will contain tracks for. Note that you can reference the same tag multiple times.
 
+While not pictured above, the `playlist_builder` supports configuring the names of playlists if you'd like them to be something other than the tag used to create them.
+For example, users may provide a map containing the `tag_content` field, which specifies the tag to use, and an optional `name` field to override the actual name of the playlist.
+Note that if `name` is not provided, `tag_content` will be used as the playlist name.
+Here's an example of overriding the name of a Hard Techno playlist to be "Techno that is hard":
+```
+    - tag_content: Hard Techno
+      name: Techno that is hard
+```
+
 Every folder will create an implicit playlist called `All <folder name>` which recursively aggregates the tracks from all the playlists within that folder. For example, my `Techno` folder will have a playlist called `All Techno` which contains the union of tracks between `Hard Techno` and `Minimal Deep Tech`.
 
 You may only have one tag for each playlist. If you're interested in creating playlists that combine multiple tags, check out the [Combiner](combiner_playlists.md) how-to guide.

--- a/docs/how_to_guides/combiner_playlists.md
+++ b/docs/how_to_guides/combiner_playlists.md
@@ -121,6 +121,14 @@ Note that the examples below are trivial ones designed to get 100% code coverage
 
 The `combiner` configuration specifies a set of `name` folders with lists of playlists and / or folders inside of them. The leaves of this playlist tree are the actual playlists themselves whose names are boolean algebra expressions that use the syntax noted above to describe how different tags and selectors are to be combined to produce the final playlist of tracks. Valid expressions must contain at least two operands and must have one less operator than there are operands. 
 
+Note that, as with the tag playlists, you may provide an override for these playlist names.
+This can be really helpful since combiner playlists can otherwise have very long names.
+Here's an example of configuring a playlist name override:
+```
+    - tag_content: "Dubstep & {date:<2022} & [5]"
+      name: Pre 2022 High Energy Dubstep
+```
+
 Once you've finalized your playlist configuration, run the following command to build the playlists:
 
 `djtools --collection-playlists`

--- a/docs/tutorials/developer_docs/playlist_filters.md
+++ b/docs/tutorials/developer_docs/playlist_filters.md
@@ -37,7 +37,7 @@ The `playlist_filters` module contains a set of `PlaylistFilter` implementations
 ### HipHopFilter
 - Checks to see if a playlist named 'Hip Hop' is a child of a playlist named 'Bass'
 - If it is, then tracks in that playlist must have a genre tag besides 'Hip Hop' and 'R&B'
-- If it is not, then tracks in that playlist must have only genre tags 'Hip Hop' and 'R&G'
+- If it is not, then tracks in that playlist must have only genre tags 'Hip Hop' and 'R&B'
 
 ::: djtools.collection.playlist_filters.HipHopFilter
     options:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "awscli==1.27.45",
     "beautifulsoup4==4.11.1",
     "fuzzywuzzy==0.18.0",
-    "lxml==4.9.2",
+    "lxml==4.9.3",
     "pydantic==1.9.1",
     "pydub==0.25.1",
     "pyperclip==1.8.2",
@@ -69,6 +69,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "aiohttp==3.9.0b1",
     "black==23.9.1",
     "build==0.8.0",
     "mkdocs==1.4.2",

--- a/src/djtools/collection/config.py
+++ b/src/djtools/collection/config.py
@@ -75,10 +75,16 @@ class CollectionConfig(BaseConfig):
                 raise RuntimeError(err) from exc
 
 
+class PlaylistName(BaseModel, extra=Extra.forbid):
+    "A class for configuring the names of playlists."
+    tag_content: str
+    name: Optional[str] = None
+
+
 class PlaylistConfigContent(BaseModel, extra=Extra.forbid):
     "A class for type checking the content of the playlist config YAML."
     name: str
-    playlists: List[Union[PlaylistConfigContent, str]]
+    playlists: List[Union[PlaylistConfigContent, PlaylistName, str]]
 
 
 class PlaylistConfig(BaseModel, extra=Extra.forbid):

--- a/tests/data/collection_playlists.yaml
+++ b/tests/data/collection_playlists.yaml
@@ -14,7 +14,8 @@ combiner:
     - name: Dubstep
       playlists:
         - "(Dubstep | Hip Hop) | (Dubstep | Hip Hop)"
-        - "Dubstep & {date:<2022} & [5]"
+        - tag_content: "Dubstep & {date:<2022} & [5]"
+          name: Pre 2022 High Energy Dubstep
     - "{artist:*Tribe*} | {comment:*Dark*} | {date:2022} | {date:<2022} | {key:7A} | {label:Some Label}"
 tags:
   name: "Tags"
@@ -40,7 +41,7 @@ tags:
               playlists:
                 - Halftime
                 - Hip Hop
-                - Pure Halftime
+                - tag_content: Pure Halftime
             - Space Bass
             - name: "[___] Step"
               playlists:


### PR DESCRIPTION
Why?
Combiner playlists are created using expressions that are defined in the name of the playlists themselves. As a result, playlists can have very long names. Renaming them after importing is always an option but should be done automatically when generating the playlist.

What?
Add a PlaylistName class to be used in collection_playlists.yaml.