### PR TITLE
feat: SimpleTrackFilter and TransitionTrackFilter

### DIFF
--- a/src/djtools/collection/config.py
+++ b/src/djtools/collection/config.py
@@ -22,7 +22,12 @@ class CollectionConfig(BaseConfig):
 
     COLLECTION_PATH: Path = None
     COLLECTION_PLAYLIST_FILTERS: List[
-        Literal["HipHopFilter", "MinimalDeepTechFilter"]
+        Literal[
+            "HipHopFilter",
+            "MinimalDeepTechFilter",
+            "SimpleTrackFilter",
+            "TransitionTrackFilter",
+        ]
     ] = []
     COLLECTION_PLAYLISTS: bool = False
     COLLECTION_PLAYLISTS_REMAINDER: Literal["folder", "playlist"] = "folder"


### PR DESCRIPTION
Why / What?
SimpleTrackFilter identifies tracks with a fewer number of non-genre tags. This can be helpful for
  (a) accelerating a library maintenance task in which these tracks have
  their tags augmented
  (b) building a playlist which can be used in future combiner playlists
  to target (in/ex)clusion of these tracks

TransitionTrackFilter identifies tracks having comments containing square bracket enclosed transition tokens which indicate that a track has one or more BPM or genre transitions.