### PR TITLE
fix: playlist_builder

### DIFF
--- a/src/djtools/collection/config.py
+++ b/src/djtools/collection/config.py
@@ -25,7 +25,7 @@ class CollectionConfig(BaseConfig):
         Literal[
             "HipHopFilter",
             "MinimalDeepTechFilter",
-            "SimpleTrackFilter",
+            "ComplexTrackFilter",
             "TransitionTrackFilter",
         ]
     ] = []

--- a/src/djtools/collection/playlist_builder.py
+++ b/src/djtools/collection/playlist_builder.py
@@ -22,6 +22,7 @@ from djtools.utils.helpers import make_path
 
 
 logger = logging.getLogger(__name__)
+PLAYLIST_NAME = "PLAYLIST_BUILDER"
 
 
 @make_path
@@ -151,7 +152,9 @@ def collection_playlists(
         if config.COLLECTION_PLAYLISTS_REMAINDER == "folder":
             auto_playlists.append(
                 build_tag_playlists(
-                    PlaylistConfigContent(name="Other", playlists=other_tags),
+                    PlaylistConfigContent(
+                        name="Unused Tags", playlists=other_tags
+                    ),
                     tags_tracks,
                     playlist_class,
                 )
@@ -159,9 +162,9 @@ def collection_playlists(
         else:
             auto_playlists.append(
                 build_tag_playlists(
-                    "Other",
+                    "Unused Tags",
                     {
-                        "Other": {
+                        "Unused Tags": {
                             track_id: track
                             for tag, track_dict in tags_tracks.items()
                             for track_id, track in track_dict.items()
@@ -199,15 +202,21 @@ def collection_playlists(
         # playlists within the same folder.
         _ = aggregate_playlists(combiner_playlists, playlist_class)
 
-        auto_playlists.append(combiner_playlists)
+        auto_playlists.extend(combiner_playlists)
 
         # Print tag statistics for each combiner playlist.
         if config.VERBOSITY and combiner_playlists:
             print_playlists_tag_statistics(combiner_playlists)
 
+    # Remove any previous playlist builder playlists.
+    previous_playlists = collection.get_playlists(name=PLAYLIST_NAME)
+    root = collection.get_playlists()
+    for playlist in previous_playlists:
+        root.remove_playlist(playlist)
+
     # Insert a new playlist containing the built playlists.
     auto_playlist = playlist_class.new_playlist(
-        name="PLAYLIST_BUILDER", playlists=auto_playlists
+        name=PLAYLIST_NAME, playlists=auto_playlists
     )
     auto_playlist.set_parent(collection.get_playlists())
     collection.add_playlist(auto_playlist)

--- a/tests/collection/test_helpers.py
+++ b/tests/collection/test_helpers.py
@@ -60,7 +60,7 @@ def test_booleannode(node_attributes):
     for operator in operators:
         node.add_operator(operator)
     for tag in tags:
-        node.add_tag(tag)
+        node.add_operand(tag)
     result = node.evaluate().keys()
     assert result == expected
 
@@ -70,7 +70,7 @@ def test_booleannode_with_multiple_expressions():
     node = BooleanNode({})
     node.add_operator("|")
     for tracks in [{2: None}, {2: None}]:
-        node.add_tracks(tracks)
+        node.add_operand(tracks)
     result = node.evaluate().keys()
     assert result == {2}
 
@@ -79,12 +79,13 @@ def test_booleannode_raises_runtime_eror():
     """Test for the BooleanNode class."""
     node = BooleanNode({})
     node.add_operator("|")
-    node.add_tag("tag")
+    node.add_operand("tag")
     with pytest.raises(
         RuntimeError,
         match=(
-            re.escape("Invalid boolean expression: track sets: 0, ")
-            + re.escape("tags: ['tag'], operators: ['union']")
+            "Invalid boolean expression:\n"
+            + re.escape("\toperands: ['tag']\n")
+            + re.escape("\toperators: ['union']")
         ),
     ):
         node.evaluate()

--- a/tests/collection/test_playlist_filters.py
+++ b/tests/collection/test_playlist_filters.py
@@ -5,9 +5,9 @@ import pytest
 
 from djtools.collection.helpers import PLATFORM_REGISTRY
 from djtools.collection.playlist_filters import (
+    ComplexTrackFilter,
     HipHopFilter,
     MinimalDeepTechFilter,
-    SimpleTrackFilter,
     TransitionTrackFilter,
 )
 from djtools.collection.tracks import RekordboxTrack
@@ -60,18 +60,18 @@ def test_minimaldeeptechfilter(techno, genre_tags, expected, rekordbox_track):
 @pytest.mark.parametrize(
     "parent_playlist_name,playlist_name,expected",
     [
-        ("something", "simple", True),
-        ("simple", "irrelevant", True),
+        ("something", "complex", True),
+        ("complex", "irrelevant", True),
         ("irrelevant", "something", False),
     ],
 )
-def test_simpletrackfilter_skips_irrelevant_playlists(
+def test_complextrackfilter_skips_irrelevant_playlists(
     parent_playlist_name,
     playlist_name,
     expected,
 ):
-    """Test for the SimpleTrackFilter class."""
-    track_filter = SimpleTrackFilter()
+    """Test for the ComplexTrackFilter class."""
+    track_filter = ComplexTrackFilter()
     playlist_class = next(iter(PLATFORM_REGISTRY.values()))["playlist"]
     playlist = playlist_class.new_playlist(playlist_name, tracks={})
     parent_playlist = playlist_class.new_playlist(
@@ -86,23 +86,25 @@ def test_simpletrackfilter_skips_irrelevant_playlists(
     "max_tags,tags,expected",
     [
         (1, set(["Tag"]), True),
-        (1, set(["Tag", "Another Tag"]), False),
-        (2, set(["Tag"]), True),
+        (2, set(["Tag"]), False),
         (2, set(["Tag", "Another Tag"]), True),
-        (2, set(["Tag", "Another Tag", "Last Tag"]), False),
+        (3, set(["Tag", "Another Tag"]), False),
+        (3, set(["Tag", "Another Tag", "Last Tag"]), True),
     ],
 )
-def test_simpletrackfilter_filters_tracks(
+def test_complextrackfilter_filters_tracks(
     max_tags, tags, expected, rekordbox_track
 ):
-    """Test for the SimpleTrackFilter class."""
-    track_filter = SimpleTrackFilter(max_tags)
+    """Test for the ComplexTrackFilter class."""
+    track_filter = ComplexTrackFilter(max_tags)
     playlist_class = next(iter(PLATFORM_REGISTRY.values()))["playlist"]
     rekordbox_track._Tags = tags  # pylint: disable=protected-access
     playlist = playlist_class.new_playlist(
         "genres", tracks={rekordbox_track.get_id(): rekordbox_track}
     )
-    root_playlist = playlist_class.new_playlist("simple", playlists=[playlist])
+    root_playlist = playlist_class.new_playlist(
+        "complex", playlists=[playlist]
+    )
     playlist.set_parent(root_playlist)
     result = track_filter.filter_track(rekordbox_track)
     assert result == expected


### PR DESCRIPTION
Why / What?
The TransitionTrackFilter should check all transition tokens.
The playlist_builder should remove previously built playlists, if any.
Playlist selectors should fail safely.
BooleanNode evaluation need to use a common set of operands (instead of managing tags and track sets separately) in order to evaluate correctly.
Switch SimpleTrackFilter to ComplexTrackFilter.