### PR TITLE
fix: make ARTIST_FIRST a global option

### DIFF
--- a/docs/conceptual_guides/file_standardization.md
+++ b/docs/conceptual_guides/file_standardization.md
@@ -29,7 +29,7 @@ Out[4]: "Track_Title (Artist2 Remix) ['Things' & Stuff!] - Artist1, Artist2.mp3"
 In general:
 
 * Keep the filenames as close as possible to the `Title (Artist2 Remix) - Artist1, Artist2` format
-    * If you use the format `Artist1, Artist2 - Title (Artist2 Remix)` instead, make sure you configure `ARTIST_FIRST` to be `true` (see [Configuration](../tutorials/getting_started/configuration.md#sync-config) for more detail)
+    * If you use the format `Artist1, Artist2 - Title (Artist2 Remix)` instead, make sure you configure `ARTIST_FIRST` to be `true` (see [Configuration](../tutorials/getting_started/configuration.md#base-config) for more detail)
 * Ensure there is only one instance of a hyphen with spaces on each side; title / artist splitting, which is needed for multiple features, will not work properly without this
 * If the track is available on Spotify, try to match the fields as close as possible to how it appears there; e.g. if the title includes `(Radio Edit)` then you should name the track accordingly
     - All of the Spotify-based features of DJ Tools work by computing the Levenshtein distance between filenames and Spotify API query results, so deviating from these names can reduce the accuracy of those features
@@ -41,7 +41,7 @@ To ensure Collection consistency and successful operation of `DJ Tools`, the fol
 1. MP3 file format
 1. Minimum 256 kbps bitrate
 1. Files named using convention: `Title (Artist2 Remix) - Artist1, Artist2`
-    * If you use the format `Artist1, Artist2 - Title (Artist2 Remix)` instead, make sure you configure `ARTIST_FIRST` to be `true` (see [Configuration](../tutorials/getting_started/configuration.md#sync-config) for more detail)
+    * If you use the format `Artist1, Artist2 - Title (Artist2 Remix)` instead, make sure you configure `ARTIST_FIRST` to be `true` (see [Configuration](../tutorials/getting_started/configuration.md#base-config) for more detail)
     * All tracks in the Beatcloud must follow the same naming convention (my instance uses track title first)
 1. `Title` and `Artist` tags populated (e.g. software: [Mp3tag](https://www.mp3tag.de/en/) or [Picard](https://picard.musicbrainz.org/))
 1. `Key` tags populated (ideally using [Mixed In Key](https://mixedinkey.com/))

--- a/docs/how_to_guides/check_beatcloud.md
+++ b/docs/how_to_guides/check_beatcloud.md
@@ -19,7 +19,7 @@ Once tracks are acquired, it may be necessary to compare a location on my comput
     - you'll have to add these manually (grab the playlist ID from the URL when opening the playlist in the browser or from the link copied when sharing a playlist in the app)
     - playlist names don't necessarily have to match the actual name of the playlist...they're just used to lookup the IDs when configuring `utils` options
 1. Configure `CHECK_TRACKS_SPOTIFY_PLAYLISTS` and / or `LOCAL_DIRS` to contain the playlist names and / or absolute paths, respectively, to the tracks you want to compare with the Beatcloud
-1. If your files are stored in the Beatcloud using the format `Artist1, Artist2 - Title (Artist2 Remix)` instead of the default `Title (Artist2 Remix) - Artist1, Artist2`, make sure you set `ARTIST_FIRST` to `true` (see [Configuration](../tutorials/getting_started/configuration.md#sync-config) for more detail)
+1. If your files are stored in the Beatcloud using the format `Artist1, Artist2 - Title (Artist2 Remix)` instead of the default `Title (Artist2 Remix) - Artist1, Artist2`, make sure you set `ARTIST_FIRST` to `true` (see [Configuration](../tutorials/getting_started/configuration.md#base-config) for more detail)
     * Note that you can temporarily set `ARTIST_FIRST` to `true` when running with `LOCAL_DIRS`, even if your Beatcloud tracks are *not* stored in the `ARTIST_FIRST` format, in order to compare against local tracks that *do* adhere to the `ARTIST_FIRST` format
 1. Run the command `djtools --check-tracks`
 

--- a/docs/tutorials/getting_started/configuration.md
+++ b/docs/tutorials/getting_started/configuration.md
@@ -6,6 +6,7 @@ If `config.yaml`, or any of the values it might contain, is missing then the def
 In fact, removing the template `config.yaml` and building a config from scratch is what I do before every new release to ensure that `config.yaml` always reflects whatever options are available in DJ Tools.
 
 ## [Base config][djtools.configs.config.BaseConfig]
+* `ARTIST_FIRST`: used to indicate that your Beatcloud tracks adhere to the `Artist1, Artist2 - Title (Artist2 Remix)` format rather than the `Title (Artist2 Remix) - Artist1, Artist2` format expected by default 
 * `LOG_LEVEL`: logger log level
 * `VERBOSITY`: verbosity level for logging messages
 
@@ -37,7 +38,6 @@ In fact, removing the template `config.yaml` and building a config from scratch 
 * `SPOTIFY_USERNAME`: Spotify username that will keep playlists automatically generated
 
 ## [Sync config][djtools.sync.config.SyncConfig]
-* `ARTIST_FIRST`: used to indicate that your Beatcloud tracks adhere to the `Artist1, Artist2 - Title (Artist2 Remix)` format rather than the `Title (Artist2 Remix) - Artist1, Artist2` format expected by default 
 * `AWS_PROFILE`: the name of the profile used when running `aws configure --profile`
 * `AWS_USE_DATE_MODIFIED`: up/download files that already exist at the destination if the date modified field at the source is after that of the destination...BE SURE THAT ALL USERS OF YOUR `BEATCLOUD` INSTANCE ARE ON BOARD BEFORE UPLOADING WITH THIS FLAG SET!
 * `DISCORD_URL`: webhook URL for messaging a Discord server's channel when new music has been uploaded to the `beatcloud`

--- a/src/djtools/configs/cli_args.py
+++ b/src/djtools/configs/cli_args.py
@@ -34,6 +34,19 @@ def get_arg_parser() -> ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--artist-first",
+        action="store_true",
+        help=(
+            "Indicate that Beatcloud tracks are in the format "
+            '"Artist - Track Title" instead of "Track Title - Artist".\nThe '
+            "ordering is important for any operation that compares your "
+            "tracks' filenames with Spotify tracks or other files...\n"
+            'This includes "--spotify-playlist-from-upload", '
+            '"--download-spotify-playlist", "--spotify-playlists", and '
+            '"--check-tracks".'
+        ),
+    )
+    parser.add_argument(
         "--log-level",
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         help="Logger level.",
@@ -239,19 +252,6 @@ def get_arg_parser() -> ArgumentParser:
             "and the Beatcloud."
         ),
         formatter_class=RawTextHelpFormatter,
-    )
-    sync_parser.add_argument(
-        "--artist-first",
-        action="store_true",
-        help=(
-            "Indicate that Beatcloud tracks are in the format "
-            '"Artist - Track Title" instead of "Track Title - Artist".\nThe '
-            "ordering is important for any operation that compares your "
-            "tracks' filenames with Spotify tracks or other files...\n"
-            'This includes "--spotify-playlist-from-upload", '
-            '"--download-spotify-playlist", "--spotify-playlists", and '
-            '"--check-tracks".'
-        ),
     )
     sync_parser.add_argument(
         "--aws-profile",

--- a/src/djtools/configs/config.py
+++ b/src/djtools/configs/config.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 class BaseConfig(BaseModel, extra=Extra.allow):
     """Base configuration object used across the whole library."""
 
+    ARTIST_FIRST: bool = False
     LOG_LEVEL: Literal[
         "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
     ] = "INFO"

--- a/src/djtools/sync/config.py
+++ b/src/djtools/sync/config.py
@@ -19,7 +19,6 @@ logger = logging.getLogger(__name__)
 class SyncConfig(BaseConfig):
     """Configuration object for the sync package."""
 
-    ARTIST_FIRST: bool = False
     AWS_PROFILE: str = "default"
     AWS_USE_DATE_MODIFIED: bool = False
     DISCORD_URL: str = ""

--- a/tests/configs/test_helpers.py
+++ b/tests/configs/test_helpers.py
@@ -120,7 +120,7 @@ def test_build_config_no_config_yaml(mock_parse_args, namespace):
     "builtins.open",
     MockOpen(
         files=["config.yaml"],
-        content="sync:\n  ARTIST_FIRST: false",
+        content="configs:\n  ARTIST_FIRST: false",
     ).open,
 )
 @mock.patch(


### PR DESCRIPTION
Why?
Overriding this value via the CLI is only possible if running `sync` commands. Setting `--artist-first` via the CLI should be possible also when running `utils` commands.

What?
Make ARTIST_FIRST a global config option.