### PR TITLE
refactor: split abstractions and implementations

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,9 +13,9 @@ import yaml
 
 from djtools.configs.config import BaseConfig
 from djtools.configs.helpers import _filter_dict, PKG_CFG
-from djtools.collection.collections import RekordboxCollection
 from djtools.collection.config import PlaylistConfig
-from djtools.collection.tracks import RekordboxTrack
+from djtools.collection.rekordbox_collection import RekordboxCollection
+from djtools.collection.rekordbox_track import RekordboxTrack
 
 
 @pytest.fixture

--- a/docs/developer_docs/new_collections.md
+++ b/docs/developer_docs/new_collections.md
@@ -20,10 +20,10 @@ In order to extend `djtools` so that these features can be used for other DJ pla
 
 
 ## Collections
-Every `Collection` subclass must implement an `__init__` that accepts a `pathlib.Path` (and also `str` if you decorate it with `@make_path`).
+Every `Collection` subclass must implement an `__init__` that accepts a `pathlib.Path` (or a `str` if you decorate it with `@make_path`).
 The `__init__` must deserialize the `Track` and `Playlist` data under the `Path` to create a `Collection` object.
 
-::: djtools.collection.collections.Collection.__init__
+::: djtools.collection.base_collection.Collection.__init__
     options:
         show_docstring_description: false
         show_docstring_parameters: false
@@ -31,7 +31,7 @@ The `__init__` must deserialize the `Track` and `Playlist` data under the `Path`
 
 The other method a `Collection` must implement is `serialize` which will write the `Collection` data in whatever format is native for that DJ platform and return the `Path` to it.
 
-::: djtools.collection.collections.Collection.serialize
+::: djtools.collection.base_collection.Collection.serialize
     options:
         show_docstring_description: false
         show_docstring_parameters: false
@@ -42,28 +42,28 @@ The other method a `Collection` must implement is `serialize` which will write t
 Subclasses of `Collection` inherit a few methods necessary to execute on the `djtools` feature set:
 
 ###### Appending a `Playlist` object to the root `Playlist`:
-::: djtools.collection.collections.Collection.add_playlist
+::: djtools.collection.base_collection.Collection.add_playlist
     options:
         show_docstring_description: false
         show_docstring_parameters: false
 ###### Getting the root `Playlist` or, if a `name` is provided, the list of `Playlist` objects with matching names (supports fuzzy matching with the `glob` parameter):
-::: djtools.collection.collections.Collection.get_playlists
+::: djtools.collection.base_collection.Collection.get_playlists
     options:
         show_docstring_description: false
         show_docstring_parameters: false
         show_docstring_returns: false
 ###### Getting the dictionary mapping track IDs to `Track` objects:
-::: djtools.collection.collections.Collection.get_tracks
+::: djtools.collection.base_collection.Collection.get_tracks
     options:
         show_docstring_description: false
         show_docstring_returns: false
 ###### Set the dictionary mapping track IDs to `Track` objects:
-::: djtools.collection.collections.Collection.set_tracks
+::: djtools.collection.base_collection.Collection.set_tracks
     options:
         show_docstring_description: false
         show_docstring_parameters: false
 ###### Get a dictionary with the sorted set of genre tags and non-genre tags:
-::: djtools.collection.collections.Collection.get_all_tags
+::: djtools.collection.base_collection.Collection.get_all_tags
     options:
         show_docstring_description: false
         show_docstring_returns: false
@@ -75,20 +75,20 @@ The two primary abstract methods are, again, `__init__` and `serialize`.
 
 The requirements for a `Track` subclass' initialization are only that it parses from the input object the dozen or so attributes that the other abstract methods either get or set:
 
-::: djtools.collection.tracks.Track.__init__
+::: djtools.collection.base_track.Track.__init__
     options:
         show_docstring_description: false
 
 A `Track` subclass must implement a `serialize` which returns an exact match of the input object used with `__init__`. In other words, it must be the case that `input == Track(input).serialize()`:
 
-::: djtools.collection.tracks.Track.serialize
+::: djtools.collection.base_track.Track.serialize
     options:
         show_docstring_description: false
         show_docstring_returns: false
 
 Let's not enumerate the many getter and setters of the `Track` object here, but you can check them out for yourself:
 
-::: djtools.collection.tracks.Track
+::: djtools.collection.base_track.Track
     options:
         show_bases: false
         members: false
@@ -101,13 +101,13 @@ Like the other components of a collection, the `Playlist` class also requires an
 
 The `__init__` method must take an input that's either a playlist folder or a playlist that contains tracks:
 
-::: djtools.collection.playlists.Playlist.__init__
+::: djtools.collection.base_playlist.Playlist.__init__
     options:
         show_docstring_description: false
 
 As with `Track`, `Playlist` subclasses must implement a `serialize` which returns an exact match of the input object used with `__init__`. In other words, it must be the case that `input == Playlist(input).serialize()`:
 
-::: djtools.collection.playlists.Playlist.serialize
+::: djtools.collection.base_playlist.Playlist.serialize
     options:
         show_docstring_description: false
         show_docstring_returns: false
@@ -118,19 +118,19 @@ The other abstract methods that must be implemented are:
 
 The `get_name` and the `is_folder` methods are a simple getter and condition check:
 
-::: djtools.collection.playlists.Playlist.get_name
+::: djtools.collection.base_playlist.Playlist.get_name
     options:
         show_docstring_description: false
         show_docstring_returns: false
 
-::: djtools.collection.playlists.Playlist.is_folder
+::: djtools.collection.base_playlist.Playlist.is_folder
     options:
         show_docstring_description: false
         show_docstring_returns: false
 
 A class method called `new_playlist` which can create a `Playlist` object from either a list of `Playlist` objects or a dictionary of `Track` objects:
 
-::: djtools.collection.playlists.Playlist.new_playlist
+::: djtools.collection.base_playlist.Playlist.new_playlist
     options:
         show_docstring_description: false
         show_docstring_parameters: false
@@ -149,14 +149,14 @@ Rekordbox supports exporting a collection to an XML file which contains two prim
 
 The `RekordboxCollection` implements `__init__` by parsing the XML with BeautifulSoup, deserializing the tracks as a dictionary of `RekordboxTrack` objects, and deserializing the playlists into the root node of a `RekordboxPlaylist` tree:
 
-::: djtools.collection.collections.RekordboxCollection.__init__
+::: djtools.collection.rekordbox_collection.RekordboxCollection.__init__
     options:
         show_docstring_description: false
         show_docstring_parameters: false
 
 The `serialize` method of `RekordboxCollection` builds a new XML document, populates the COLLECTION tag by serializing the values of the `RekordboxTrack` dictionary, and then populates the PLAYLISTS tag by iterating the root `RekordboxPlaylist` and serializing its children:
 
-::: djtools.collection.collections.RekordboxCollection.serialize
+::: djtools.collection.rekordbox_collection.RekordboxCollection.serialize
     options:
         show_docstring_description: false
         show_docstring_parameters: false
@@ -168,14 +168,14 @@ A track in an XML contains all the information about tracks except for what play
 
 The `RekordboxTrack` implements `__init__` by enumerating the attributes of the input Track tag and deserializing the string values as types that are more useful in Python, such as `datetime` objects, `lists`, `sets`, and numerical values:
 
-::: djtools.collection.tracks.RekordboxTrack.__init__
+::: djtools.collection.rekordbox_track.RekordboxTrack.__init__
     options:
         show_docstring_description: false
         show_docstring_parameters: false
 
 The `serialize` method of `RekordboxTrack` builds a new XML tag for a TRACK and populates the attributes of that tag using the `RekordboxTrack` members. Because Rekordbox serializes TRACK tags inside of the PLAYLISTS differently, this method accepts a parameter to indicate that the `RekordboxTrack` should serialize containing only its ID:
 
-::: djtools.collection.tracks.RekordboxTrack.serialize
+::: djtools.collection.rekordbox_track.RekordboxTrack.serialize
     options:
         show_docstring_description: false
         show_docstring_parameters: false
@@ -190,14 +190,14 @@ NODE tags also have attributes for the Name and Type (folder or not) and either 
 
 The `__init__` method deserializes a NODE tag by either recursively deserializing its children NODE tags (if it's a folder) or else creating a dictionary of tracks from `RekordboxCollection` object's tracks passed as a parameter:
 
-::: djtools.collection.playlists.RekordboxPlaylist.__init__
+::: djtools.collection.rekordbox_playlist.RekordboxPlaylist.__init__
     options:
         show_docstring_description: false
         show_docstring_parameters: false
 
 The `new_playlist` method creates a new Node tag and deserializes it as a `RekordboxPlaylist` before setting its members with either a `RekordboxTrack` dictionary or a list of `RekordboxPlaylist` objects:
 
-::: djtools.collection.playlists.RekordboxPlaylist.new_playlist
+::: djtools.collection.rekordbox_playlist.RekordboxPlaylist.new_playlist
     options:
         show_docstring_description: false
         show_docstring_parameters: false
@@ -206,7 +206,7 @@ The `new_playlist` method creates a new Node tag and deserializes it as a `Rekor
     
 The `serialize` method of `RekordboxPlaylist` builds a new XML tag for a NODE and populates the attributes and sub-tags recursively:
 
-::: djtools.collection.playlists.RekordboxPlaylist.serialize
+::: djtools.collection.rekordbox_playlist.RekordboxPlaylist.serialize
     options:
         show_docstring_description: false
         show_docstring_returns: false

--- a/docs/reference/collection/index.md
+++ b/docs/reference/collection/index.md
@@ -1,11 +1,14 @@
 # Collection
 
 ::: djtools.collection.config
-::: djtools.collection.collections
-::: djtools.collection.playlists
-::: djtools.collection.tracks
 ::: djtools.collection.playlist_builder
 ::: djtools.collection.playlist_filters
+::: djtools.collection.base_collection
+::: djtools.collection.rekordbox_collection
+::: djtools.collection.base_playlist
+::: djtools.collection.rekordbox_playlist
+::: djtools.collection.base_track
+::: djtools.collection.rekordbox_track
 ::: djtools.collection.shuffle_playlists
 ::: djtools.collection.copy_playlists
 ::: djtools.collection.helpers

--- a/scripts/collection/cluster_tracks.py
+++ b/scripts/collection/cluster_tracks.py
@@ -7,10 +7,10 @@ import pandas as pd
 from sklearn.cluster import DBSCAN, KMeans, SpectralClustering
 from tqdm import tqdm
 
-from djtools.collection.collections import Collection
-from djtools.collection.playlists import Playlist
+from djtools.collection.base_collection import Collection
+from djtools.collection.base_playlist import Playlist
 from djtools.collection.helpers import PLATFORM_REGISTRY
-from djtools.collection.tracks import Track
+from djtools.collection.base_track import Track
 from djtools.configs import build_config
 
 

--- a/scripts/collection/user_vibe_analysis.py
+++ b/scripts/collection/user_vibe_analysis.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 from matplotlib.ticker import MaxNLocator
 
 from djtools.configs import build_config
-from djtools.collection.collections import Collection
+from djtools.collection.base_collection import Collection
 from djtools.collection.helpers import PLATFORM_REGISTRY
 
 

--- a/scripts/repair/normalize_audio.py
+++ b/scripts/repair/normalize_audio.py
@@ -12,8 +12,8 @@ import matplotlib.pyplot as plt
 from pydub import AudioSegment, effects, utils
 from tqdm import tqdm
 
-from djtools.collection.collections import RekordboxCollection
-from djtools.collection.tracks import RekordboxTrack
+from djtools.collection.rekordbox_collection import RekordboxCollection
+from djtools.collection.rekordbox_track import RekordboxTrack
 
 
 def thread(track: RekordboxTrack, data_dict: Dict):

--- a/scripts/repair/rename_files.py
+++ b/scripts/repair/rename_files.py
@@ -87,8 +87,8 @@ import eyed3
 from pydub import AudioSegment
 from tqdm import tqdm
 
-from djtools.collection.collections import RekordboxCollection
-from djtools.collection.tracks import RekordboxTrack
+from djtools.collection.rekordbox_collection import RekordboxCollection
+from djtools.collection.rekordbox_track import RekordboxTrack
 from djtools.configs.cli_args import convert_to_paths
 
 

--- a/src/djtools/collection/__init__.py
+++ b/src/djtools/collection/__init__.py
@@ -1,5 +1,7 @@
 """The `collection` package contains modules:
-    * `collections`: abstractions and implementations for collections
+    * `base_collection`: abstraction for Collection
+    * `base_playlist`: abstraction for Playlist
+    * `base_track`: abstraction for Track
     * `config`: the configuration object for the `collection` package
     * `copy_playlists`: copies audio files for tracks within a set of
         playlists to a new location and writes a new collection with these
@@ -11,17 +13,20 @@
         `collection_playlists.yaml`
     * `playlist_filters`: abstractions and implementations for playlist filters
     * `playlists`: abstractions and implementations for playlists
+    * `rekordbox_collection`: implementation of Collection for Rekordbox
+    * `rekordbox_playlist`: implementation of Playlist for Rekordbox
+    * `rekordbox_track`: implementation of Track for Rekordbox
     * `shuffle_playlists`: writes sequential numbers to tags of shuffled tracks
         in playlists to emulate playlist shuffling
     * `tracks`: abstractions and implementations for tracks
 """
 
-from djtools.collection.collections import RekordboxCollection
 from djtools.collection.copy_playlists import copy_playlists
 from djtools.collection.playlist_builder import collection_playlists
-from djtools.collection.playlists import RekordboxPlaylist
+from djtools.collection.rekordbox_collection import RekordboxCollection
+from djtools.collection.rekordbox_playlist import RekordboxPlaylist
+from djtools.collection.rekordbox_track import RekordboxTrack
 from djtools.collection.shuffle_playlists import shuffle_playlists
-from djtools.collection.tracks import RekordboxTrack
 
 
 COLLECTION_OPERATIONS = {

--- a/src/djtools/collection/base_collection.py
+++ b/src/djtools/collection/base_collection.py
@@ -1,0 +1,109 @@
+"""This module contains the base class for collections of different DJ software
+platforms.
+
+Collection is an abstract base class which defines the interface expected of a
+collection; namely methods for (de)serialization to/from the representation
+recognized by the DJ software for which Collection is being sub-classed.
+"""
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from pathlib import Path
+import re
+from typing import Dict, List, Optional, Union
+
+from djtools.collection.base_playlist import Playlist
+from djtools.collection.base_track import Track
+
+
+class Collection(ABC):
+    "Abstract base class for a collection."
+
+    @abstractmethod
+    def __init__(self, path: Path, *args, **kwargs):
+        """Deserializes a collection from the native format of a DJ software.
+
+        Args:
+            path: Path to a serialized collection.
+        """
+
+    def add_playlist(self, playlist: Playlist):
+        """Appends a playlist to the collection.
+
+        Args:
+            playlist: Playlist to append to the collection.
+        """
+        self._playlists.add_playlist(playlist)  # pylint:disable=no-member
+
+    def get_all_tags(self) -> Dict[str, List[str]]:
+        """Returns the all tags in the collection.
+
+        Returns:
+            Dict containing all track tags keyed by "genres" and "other".
+        """
+        all_tags = {
+            tag
+            for track in self.get_tracks().values()
+            for tag in track.get_tags()
+        }
+        genre_tags = {
+            tag
+            for track in self.get_tracks().values()
+            for tag in track.get_genre_tags()
+        }
+        other_tags = all_tags.difference(genre_tags)
+
+        return {"genres": sorted(genre_tags), "other": sorted(other_tags)}
+
+    def get_playlists(
+        self, name: Optional[str] = None, glob: Optional[bool] = False
+    ) -> Union[Playlist, List[Playlist]]:
+        """Returns Playlists with a matching name.
+
+        If no playlist name is provided, then the root playlist is returned.
+
+        Args:
+            name: Name of the Playlists to return.
+            glob: Glob on playlist name containing "*".
+
+        Returns:
+            The Playlists with the same name.
+        """
+        if not name:
+            return self._playlists  # pylint:disable=no-member
+
+        exp = re.compile(r".*".join(name.split("*")))
+        playlists = []
+        for playlist in self._playlists:  # pylint:disable=no-member
+            if (glob and re.search(exp, playlist.get_name())) or (
+                not glob and playlist.get_name() == name
+            ):
+                playlists.append(playlist)
+            if playlist.is_folder():
+                for playlist in playlist:
+                    playlists.extend(playlist.get_playlists(name, glob=glob))
+
+        return [playlist for playlist in playlists if playlist is not None]
+
+    def get_tracks(self) -> Dict[str, Track]:
+        """Returns the tracks in the collection.
+
+        Returns:
+            Dict of tracks.
+        """
+        return self._tracks
+
+    @abstractmethod
+    def serialize(self, *args, **kwargs) -> Path:
+        """Serialize a collection into the native format of a DJ software.
+
+        Returns:
+            A path to a serialized collection.
+        """
+
+    def set_tracks(self, tracks: Dict[str, Track]):
+        """Sets the tracks of this collection.
+
+        Args:
+            tracks: Tracks to set.
+        """
+        self._tracks = tracks  # pylint:disable=attribute-defined-outside-init

--- a/src/djtools/collection/base_playlist.py
+++ b/src/djtools/collection/base_playlist.py
@@ -1,0 +1,207 @@
+"""This module contains the base class for playlists of different DJ software
+platforms.
+
+Playlist is an abstract base class which defines the interface expected of a
+playlist; namely methods for (de)serialization to/from the representation
+recognized by the DJ software for which Playlist is being sub-classed.
+"""
+from __future__ import annotations
+from abc import ABC, abstractmethod
+import re
+from typing import Any, Dict, List, Optional
+
+from djtools.collection.base_track import Track
+
+
+# pylint: disable=duplicate-code
+
+
+class Playlist(ABC):
+    "Abstract base class for a playlist."
+
+    @abstractmethod
+    def __init__(self, *args, **kwargs):
+        "Deserializes a playlist from the native format of a DJ software."
+
+    def __getitem__(self, index: int) -> Playlist:
+        """Gets a Playlist from this Playlist's playlists.
+
+        This method is used to iterate this object during serialization. If
+        this Playlist is a folder, then it returns elements from
+        self._playlists for serialization.
+
+        Args:
+            index: The index of the Playlist to get.
+
+        Returns:
+            A Playlist.
+        """
+        return self._playlists[index]
+
+    def __len__(self) -> int:
+        """Returns the number of elements in this Playlist.
+
+        If this Playlist is a folder, it returns the number of Playlists within
+        it. If this Playlist is instead an actual playlist, then it returns the
+        number of Tracks it contains.
+
+        Returns:
+            The number of elements in this Playlist.
+        """
+        if self.is_folder():
+            return len(self._playlists)
+        return len(self._tracks)
+
+    def add_playlist(self, playlist: Playlist, index: Optional[int] = None):
+        """Adds a playlist to this folder-type playlist.
+
+        Args:
+            playlist: Playlist to add.
+            index: Insert the playlist at a specific index.
+
+        Raises:
+            RuntimeError: Only folder Playlists can be added to.
+        """
+        if not self.is_folder():
+            raise RuntimeError("You can't append to a non-folder Playlist")
+        if index is not None:
+            self._playlists.insert(index, playlist)
+        else:
+            self._playlists.append(playlist)
+
+    @abstractmethod
+    def get_name(self) -> str:
+        """Returns the name of this playlist.
+
+        Returns:
+            The name of this playlist.
+        """
+
+    def get_parent(self) -> Optional[Playlist]:
+        """Returns the folder this playlist is in.
+
+        Returns:
+            A Playlist folder or None (if no parent).
+        """
+        return self._parent
+
+    def get_playlists(
+        self, name: Optional[str] = None, glob: Optional[bool] = False
+    ) -> List[Playlist]:
+        """Returns Playlists with a matching name.
+
+        Args:
+            name: Name of the Playlists to return.
+            glob: Glob on playlist name containing "*".
+
+        Returns:
+            The Playlists with the same name.
+        """
+        if not name:
+            if not self.is_folder():
+                raise RuntimeError(
+                    f'Playlist "{self.get_name()}" is not a folder so you '
+                    f"cannot call get_playlists on it."
+                )
+            return list(self)
+
+        exp = re.compile(r".*".join(name.split("*")))
+        playlists = []
+        if (glob and re.search(exp, self.get_name())) or (
+            not glob and self.get_name() == name
+        ):
+            playlists.append(self)
+        if self.is_folder():
+            for playlist in self:
+                playlists.extend(playlist.get_playlists(name, glob=glob))
+
+        return [playlist for playlist in playlists if playlist is not None]
+
+    def get_tracks(self) -> Dict[str, Track]:
+        """Returns a dict of track IDs and tracks.
+
+        Returns:
+            A dict of track IDs and tracks.
+        """
+        return self._tracks
+
+    @abstractmethod
+    def is_folder(self) -> bool:
+        """Returns whether this playlist is a folder or a playlist of tracks.
+
+        Returns:
+            Boolean representing whether this is a folder or not.
+        """
+
+    @classmethod
+    @abstractmethod
+    def new_playlist(
+        cls,
+        name: str,
+        playlists: Optional[List[Playlist]] = None,
+        tracks: Optional[Dict[str, Track]] = None,
+    ) -> Playlist:
+        """Creates a new Playlist.
+
+        Args:
+            name: The name of the Playlist to be created.
+            playlists: A list of Playlists to add to this Playlist.
+            tracks: A dict of Tracks to add to this Playlist.
+
+        Raises:
+            RuntimeError: You must provide either a list of Playlists or a list
+                of Tracks.
+            RuntimeError: You must not provide both a list of Playlists and a
+                list of Tracks.
+
+        Returns:
+            A new Playlist.
+        """
+
+    def remove_playlist(self, playlist: Playlist):
+        """Removes playlist from list of playlists.
+
+        Args:
+            playlist: Playlist to remove.
+
+        Raises:
+            RuntimeError: Can't remove playlist from a non-folder playlist.
+        """
+        if not self.is_folder():
+            raise RuntimeError(
+                "Can't remove playlist from a non-folder playlist."
+            )
+        self._playlists = [  # pylint: disable=attribute-defined-outside-init
+            _playlist
+            for _playlist in self._playlists
+            if _playlist is not playlist
+        ]
+
+    @abstractmethod
+    def serialize(self, *args, **kwargs) -> Any:
+        """Serializes a playlist into the native format of a DJ software.
+
+        Returns:
+            A serialized playlist of the same type used to initialized
+                Playlist.
+        """
+
+    def set_parent(self, parent: Optional[Playlist] = None):
+        """Recursively sets the parent of all playlists within.
+
+        Args:
+            parent: Playlist to set as the parent.
+        """
+        self._parent = parent  # pylint: disable=attribute-defined-outside-init
+        if not self.is_folder():
+            return
+        for child in self:
+            child.set_parent(self)
+
+    def set_tracks(self, tracks: Dict[str, Track]):
+        """Sets the tracks of this playlist.
+
+        Args:
+            tracks: A dict of Tracks to override for this Playlist.
+        """
+        self._tracks = tracks  # pylint: disable=attribute-defined-outside-init

--- a/src/djtools/collection/base_track.py
+++ b/src/djtools/collection/base_track.py
@@ -1,0 +1,142 @@
+"""This module contains the base class for tracks of different DJ software
+platforms.
+
+Track is an abstract base class which defines the interface expected of a
+track; namely methods for (de)serialization to/from the representation
+recognized by the DJ software for which Track is being sub-classed.
+"""
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, List
+
+
+# pylint: disable=no-member,duplicate-code
+
+
+class Track(ABC):
+    "Abstract base class for a track."
+
+    @abstractmethod
+    def __init__(self, *args, **kwargs):
+        "Deserializes a track from the native format of a DJ software."
+
+    @abstractmethod
+    def get_artists(self) -> str:
+        """Gets the track artists.
+
+        Returns:
+            A string representing the track's artists.
+        """
+
+    @abstractmethod
+    def get_bpm(self) -> float:
+        """Gets the track BPM.
+
+        Returns:
+            A float representing BPM.
+        """
+
+    @abstractmethod
+    def get_comments(self) -> str:
+        """Gets the track comments.
+
+        Returns:
+            A string representing the track's comments.
+        """
+
+    @abstractmethod
+    def get_date_added(self) -> str:
+        """Gets the track's date added.
+
+        Returns:
+            A datetime representing the track's date added.
+        """
+
+    @abstractmethod
+    def get_genre_tags(self) -> List[str]:
+        """Gets the genre tags of the track.
+
+        Returns:
+            A list of the track's genre tags.
+        """
+
+    @abstractmethod
+    def get_id(self) -> Any:
+        """Gets the track ID.
+
+        Returns:
+            The ID of this track.
+        """
+
+    @abstractmethod
+    def get_key(self) -> Any:
+        """Gets the track key.
+
+        Returns:
+            The key of this track.
+        """
+
+    @abstractmethod
+    def get_label(self) -> Any:
+        """Gets the track label.
+
+        Returns:
+            The label of this track.
+        """
+
+    @abstractmethod
+    def get_location(self) -> Path:
+        """Gets the location of the track.
+
+        Returns:
+            The Path for the location of the track.
+        """
+
+    @abstractmethod
+    def get_rating(self) -> int:
+        """Gets the rating of the track.
+
+        Returns:
+            The rating of the track.
+        """
+
+    @abstractmethod
+    def get_tags(self) -> List[str]:
+        """Gets the tags of the track.
+
+        Returns:
+            A set of the track's tags.
+        """
+
+    @abstractmethod
+    def get_year(self) -> str:
+        """Gets the year of the track.
+
+        Returns:
+            The year of the track.
+        """
+
+    @abstractmethod
+    def serialize(self, *args, **kwargs) -> Any:
+        """Serializes a track into the native format of a DJ software.
+
+        Returns:
+            A serialized track of the same type used to initialize Track.
+        """
+
+    @abstractmethod
+    def set_location(self, location: Path):
+        """Sets the path of the track to location.
+
+        Args:
+            location: New location of the track.
+        """
+
+    @abstractmethod
+    def set_track_number(self, number: int):
+        """Sets the track number of a track.
+
+        Args:
+            number: Number to set for TrackNumber.
+        """

--- a/src/djtools/collection/helpers.py
+++ b/src/djtools/collection/helpers.py
@@ -9,15 +9,18 @@ import re
 import shutil
 from typing import Dict, List, Optional, Set, Tuple, Union
 
-from djtools.collection.collections import Collection, RekordboxCollection
+from djtools.collection.base_collection import Collection
+from djtools.collection.base_playlist import Playlist
+from djtools.collection.base_track import Track
 from djtools.collection.config import (
     PlaylistConfig,
     PlaylistConfigContent,
     PlaylistName,
 )
 from djtools.collection.playlist_filters import PlaylistFilter
-from djtools.collection.playlists import Playlist, RekordboxPlaylist
-from djtools.collection.tracks import Track, RekordboxTrack
+from djtools.collection.rekordbox_collection import RekordboxCollection
+from djtools.collection.rekordbox_playlist import RekordboxPlaylist
+from djtools.collection.rekordbox_track import RekordboxTrack
 from djtools.utils.helpers import make_path
 
 

--- a/src/djtools/collection/playlist_filters.py
+++ b/src/djtools/collection/playlist_filters.py
@@ -14,8 +14,8 @@ from abc import ABC, abstractmethod
 import re
 from typing import List, Optional
 
-from djtools.collection.playlists import Playlist
-from djtools.collection.tracks import Track
+from djtools.collection.base_playlist import Playlist
+from djtools.collection.base_track import Track
 
 
 class PlaylistFilter(ABC):

--- a/src/djtools/collection/rekordbox_collection.py
+++ b/src/djtools/collection/rekordbox_collection.py
@@ -1,123 +1,24 @@
-"""This module contains classes for collections of different DJ software
-platforms.
-
-Collection is an abstract base class which defines the interface expected of a
-collection; namely methods for (de)serialization to/from the representation
-recognized by the DJ software for which Collection is being sub-classed.
+"""This module contains the class for the RekordboxCollection.
 
 RekordboxCollection is an implementation of Collection which operates on the
 XML format that Rekordbox exports. The CustomSubstitution and
 UnsortedAttributes classes are helpers for serializing a RekordboxCollection.
 """
 from __future__ import annotations
-from abc import ABC, abstractmethod
 from copy import copy
 from pathlib import Path
 import re
-from typing import Dict, Iterator, List, Optional, Tuple, Union
+from typing import Iterator, Optional, Tuple
 
 import bs4
 from bs4 import BeautifulSoup
 from bs4.dammit import EntitySubstitution
 from bs4.formatter import XMLFormatter
 
-from djtools.collection.playlists import Playlist, RekordboxPlaylist
-from djtools.collection.tracks import RekordboxTrack, Track
+from djtools.collection.base_collection import Collection
+from djtools.collection.rekordbox_playlist import RekordboxPlaylist
+from djtools.collection.rekordbox_track import RekordboxTrack
 from djtools.utils.helpers import make_path
-
-
-class Collection(ABC):
-    "Abstract base class for a collection."
-
-    @abstractmethod
-    def __init__(self, path: Path, *args, **kwargs):
-        """Deserializes a collection from the native format of a DJ software.
-
-        Args:
-            path: Path to a serialized collection.
-        """
-
-    def add_playlist(self, playlist: Playlist):
-        """Appends a playlist to the collection.
-
-        Args:
-            playlist: Playlist to append to the collection.
-        """
-        self._playlists.add_playlist(playlist)  # pylint:disable=no-member
-
-    def get_all_tags(self) -> Dict[str, List[str]]:
-        """Returns the all tags in the collection.
-
-        Returns:
-            Dict containing all track tags keyed by "genres" and "other".
-        """
-        all_tags = {
-            tag
-            for track in self.get_tracks().values()
-            for tag in track.get_tags()
-        }
-        genre_tags = {
-            tag
-            for track in self.get_tracks().values()
-            for tag in track.get_genre_tags()
-        }
-        other_tags = all_tags.difference(genre_tags)
-
-        return {"genres": sorted(genre_tags), "other": sorted(other_tags)}
-
-    def get_playlists(
-        self, name: Optional[str] = None, glob: Optional[bool] = False
-    ) -> Union[Playlist, List[Playlist]]:
-        """Returns Playlists with a matching name.
-
-        If no playlist name is provided, then the root playlist is returned.
-
-        Args:
-            name: Name of the Playlists to return.
-            glob: Glob on playlist name containing "*".
-
-        Returns:
-            The Playlists with the same name.
-        """
-        if not name:
-            return self._playlists  # pylint:disable=no-member
-
-        exp = re.compile(r".*".join(name.split("*")))
-        playlists = []
-        for playlist in self._playlists:  # pylint:disable=no-member
-            if (glob and re.search(exp, playlist.get_name())) or (
-                not glob and playlist.get_name() == name
-            ):
-                playlists.append(playlist)
-            if playlist.is_folder():
-                for playlist in playlist:
-                    playlists.extend(playlist.get_playlists(name, glob=glob))
-
-        return [playlist for playlist in playlists if playlist is not None]
-
-    def get_tracks(self) -> Dict[str, Track]:
-        """Returns the tracks in the collection.
-
-        Returns:
-            Dict of tracks.
-        """
-        return self._tracks
-
-    @abstractmethod
-    def serialize(self, *args, **kwargs) -> Path:
-        """Serialize a collection into the native format of a DJ software.
-
-        Returns:
-            A path to a serialized collection.
-        """
-
-    def set_tracks(self, tracks: Dict[str, Track]):
-        """Sets the tracks of this collection.
-
-        Args:
-            tracks: Tracks to set.
-        """
-        self._tracks = tracks  # pylint:disable=attribute-defined-outside-init
 
 
 class RekordboxCollection(Collection):

--- a/src/djtools/collection/rekordbox_playlist.py
+++ b/src/djtools/collection/rekordbox_playlist.py
@@ -1,217 +1,20 @@
-"""This module contains classes for playlists of different DJ software
-platforms.
-
-Playlist is an abstract base class which defines the interface expected of a
-playlist; namely methods for (de)serialization to/from the representation
-recognized by the DJ software for which Playlist is being sub-classed.
+"""This module contains the class for RekordbxPlaylist.
 
 RekordboxPlaylist is an implementation of Playlist which operates on the XML
 format that Rekordbox exports.
 """
 from __future__ import annotations
-from abc import ABC, abstractmethod
 import inspect
 from pathlib import Path
-import re
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 import bs4
 
-from djtools.collection.tracks import RekordboxTrack, Track
+from djtools.collection.base_playlist import Playlist
+from djtools.collection.rekordbox_track import RekordboxTrack
 
 
 # pylint: disable=duplicate-code
-
-
-class Playlist(ABC):
-    "Abstract base class for a playlist."
-
-    @abstractmethod
-    def __init__(self, *args, **kwargs):
-        "Deserializes a playlist from the native format of a DJ software."
-
-    def __getitem__(self, index: int) -> Playlist:
-        """Gets a Playlist from this Playlist's playlists.
-
-        This method is used to iterate this object during serialization. If
-        this Playlist is a folder, then it returns elements from
-        self._playlists for serialization.
-
-        Args:
-            index: The index of the Playlist to get.
-
-        Returns:
-            A Playlist.
-        """
-        return self._playlists[index]
-
-    def __len__(self) -> int:
-        """Returns the number of elements in this Playlist.
-
-        If this Playlist is a folder, it returns the number of Playlists within
-        it. If this Playlist is instead an actual playlist, then it returns the
-        number of Tracks it contains.
-
-        Returns:
-            The number of elements in this Playlist.
-        """
-        if self.is_folder():
-            return len(self._playlists)
-        return len(self._tracks)
-
-    def add_playlist(self, playlist: Playlist, index: Optional[int] = None):
-        """Adds a playlist to this folder-type playlist.
-
-        Args:
-            playlist: Playlist to add.
-            index: Insert the playlist at a specific index.
-
-        Raises:
-            RuntimeError: Only folder Playlists can be added to.
-        """
-        if not self.is_folder():
-            raise RuntimeError("You can't append to a non-folder Playlist")
-        if index is not None:
-            self._playlists.insert(index, playlist)
-        else:
-            self._playlists.append(playlist)
-
-    @abstractmethod
-    def get_name(self) -> str:
-        """Returns the name of this playlist.
-
-        Returns:
-            The name of this playlist.
-        """
-
-    def get_parent(self) -> Optional[Playlist]:
-        """Returns the folder this playlist is in.
-
-        Returns:
-            A Playlist folder or None (if no parent).
-        """
-        return self._parent
-
-    def get_playlists(
-        self, name: Optional[str] = None, glob: Optional[bool] = False
-    ) -> List[Playlist]:
-        """Returns Playlists with a matching name.
-
-        Args:
-            name: Name of the Playlists to return.
-            glob: Glob on playlist name containing "*".
-
-        Returns:
-            The Playlists with the same name.
-        """
-        if not name:
-            if not self.is_folder():
-                raise RuntimeError(
-                    f'Playlist "{self.get_name()}" is not a folder so you '
-                    f"cannot call get_playlists on it."
-                )
-            return list(self)
-
-        exp = re.compile(r".*".join(name.split("*")))
-        playlists = []
-        if (glob and re.search(exp, self.get_name())) or (
-            not glob and self.get_name() == name
-        ):
-            playlists.append(self)
-        if self.is_folder():
-            for playlist in self:
-                playlists.extend(playlist.get_playlists(name, glob=glob))
-
-        return [playlist for playlist in playlists if playlist is not None]
-
-    def get_tracks(self) -> Dict[str, Track]:
-        """Returns a dict of track IDs and tracks.
-
-        Returns:
-            A dict of track IDs and tracks.
-        """
-        return self._tracks
-
-    @abstractmethod
-    def is_folder(self) -> bool:
-        """Returns whether this playlist is a folder or a playlist of tracks.
-
-        Returns:
-            Boolean representing whether this is a folder or not.
-        """
-
-    @classmethod
-    @abstractmethod
-    def new_playlist(
-        cls,
-        name: str,
-        playlists: Optional[List[Playlist]] = None,
-        tracks: Optional[Dict[str, Track]] = None,
-    ) -> Playlist:
-        """Creates a new Playlist.
-
-        Args:
-            name: The name of the Playlist to be created.
-            playlists: A list of Playlists to add to this Playlist.
-            tracks: A dict of Tracks to add to this Playlist.
-
-        Raises:
-            RuntimeError: You must provide either a list of Playlists or a list
-                of Tracks.
-            RuntimeError: You must not provide both a list of Playlists and a
-                list of Tracks.
-
-        Returns:
-            A new Playlist.
-        """
-
-    def remove_playlist(self, playlist: Playlist):
-        """Removes playlist from list of playlists.
-
-        Args:
-            playlist: Playlist to remove.
-
-        Raises:
-            RuntimeError: Can't remove playlist from a non-folder playlist.
-        """
-        if not self.is_folder():
-            raise RuntimeError(
-                "Can't remove playlist from a non-folder playlist."
-            )
-        self._playlists = [  # pylint: disable=attribute-defined-outside-init
-            _playlist
-            for _playlist in self._playlists
-            if _playlist is not playlist
-        ]
-
-    @abstractmethod
-    def serialize(self, *args, **kwargs) -> Any:
-        """Serializes a playlist into the native format of a DJ software.
-
-        Returns:
-            A serialized playlist of the same type used to initialized
-                Playlist.
-        """
-
-    def set_parent(self, parent: Optional[Playlist] = None):
-        """Recursively sets the parent of all playlists within.
-
-        Args:
-            parent: Playlist to set as the parent.
-        """
-        self._parent = parent  # pylint: disable=attribute-defined-outside-init
-        if not self.is_folder():
-            return
-        for child in self:
-            child.set_parent(self)
-
-    def set_tracks(self, tracks: Dict[str, Track]):
-        """Sets the tracks of this playlist.
-
-        Args:
-            tracks: A dict of Tracks to override for this Playlist.
-        """
-        self._tracks = tracks  # pylint: disable=attribute-defined-outside-init
 
 
 class RekordboxPlaylist(Playlist):
@@ -282,7 +85,7 @@ class RekordboxPlaylist(Playlist):
                     frame
                     for frame in inspect.stack()
                     if frame[3] == "__repr__"
-                    and Path(frame[1]).name == "playlists.py"
+                    and Path(frame[1]).name == "rekordbox_playlist.py"
                 ]
             )
             - 1

--- a/src/djtools/collection/rekordbox_track.py
+++ b/src/djtools/collection/rekordbox_track.py
@@ -1,14 +1,9 @@
-"""This module contains classes for tracks of different DJ software platforms.
-
-Track is an abstract base class which defines the interface expected of a
-track; namely methods for (de)serialization to/from the representation
-recognized by the DJ software for which Track is being sub-classed.
+"""This module contains the class for RekordboxTrack.
 
 RekordboxTrack is an implementation of Track which operates on the XML format
 that Rekordbox exports.
 """
 from __future__ import annotations
-from abc import ABC, abstractmethod
 from datetime import datetime
 import os
 from pathlib import Path
@@ -18,138 +13,11 @@ from urllib.parse import quote, unquote
 
 import bs4
 
+from djtools.collection.base_track import Track
 from djtools.utils.helpers import make_path
 
 
 # pylint: disable=no-member,duplicate-code
-
-
-class Track(ABC):
-    "Abstract base class for a track."
-
-    @abstractmethod
-    def __init__(self, *args, **kwargs):
-        "Deserializes a track from the native format of a DJ software."
-
-    @abstractmethod
-    def get_artists(self) -> str:
-        """Gets the track artists.
-
-        Returns:
-            A string representing the track's artists.
-        """
-
-    @abstractmethod
-    def get_bpm(self) -> float:
-        """Gets the track BPM.
-
-        Returns:
-            A float representing BPM.
-        """
-
-    @abstractmethod
-    def get_comments(self) -> str:
-        """Gets the track comments.
-
-        Returns:
-            A string representing the track's comments.
-        """
-
-    @abstractmethod
-    def get_date_added(self) -> str:
-        """Gets the track's date added.
-
-        Returns:
-            A datetime representing the track's date added.
-        """
-
-    @abstractmethod
-    def get_genre_tags(self) -> List[str]:
-        """Gets the genre tags of the track.
-
-        Returns:
-            A list of the track's genre tags.
-        """
-
-    @abstractmethod
-    def get_id(self) -> Any:
-        """Gets the track ID.
-
-        Returns:
-            The ID of this track.
-        """
-
-    @abstractmethod
-    def get_key(self) -> Any:
-        """Gets the track key.
-
-        Returns:
-            The key of this track.
-        """
-
-    @abstractmethod
-    def get_label(self) -> Any:
-        """Gets the track label.
-
-        Returns:
-            The label of this track.
-        """
-
-    @abstractmethod
-    def get_location(self) -> Path:
-        """Gets the location of the track.
-
-        Returns:
-            The Path for the location of the track.
-        """
-
-    @abstractmethod
-    def get_rating(self) -> int:
-        """Gets the rating of the track.
-
-        Returns:
-            The rating of the track.
-        """
-
-    @abstractmethod
-    def get_tags(self) -> List[str]:
-        """Gets the tags of the track.
-
-        Returns:
-            A set of the track's tags.
-        """
-
-    @abstractmethod
-    def get_year(self) -> str:
-        """Gets the year of the track.
-
-        Returns:
-            The year of the track.
-        """
-
-    @abstractmethod
-    def serialize(self, *args, **kwargs) -> Any:
-        """Serializes a track into the native format of a DJ software.
-
-        Returns:
-            A serialized track of the same type used to initialize Track.
-        """
-
-    @abstractmethod
-    def set_location(self, location: Path):
-        """Sets the path of the track to location.
-
-        Args:
-            location: New location of the track.
-        """
-
-    @abstractmethod
-    def set_track_number(self, number: int):
-        """Sets the track number of a track.
-
-        Args:
-            number: Number to set for TrackNumber.
-        """
 
 
 class RekordboxTrack(Track):

--- a/tests/collection/test_base_collection.py
+++ b/tests/collection/test_base_collection.py
@@ -1,0 +1,15 @@
+"""Testing for the collection module."""
+import pytest
+
+from djtools.collection.base_collection import Collection
+
+
+def test_collection_raises_type_error():
+    """Test Collection class."""
+    with pytest.raises(
+        TypeError,
+        match=(
+            "Can't instantiate abstract class Collection with abstract method"
+        ),
+    ):
+        Collection(path="")

--- a/tests/collection/test_base_playlist.py
+++ b/tests/collection/test_base_playlist.py
@@ -1,0 +1,15 @@
+"""Testing for the playlists module."""
+import pytest
+
+from djtools.collection.base_playlist import Playlist
+
+
+def test_playlist_raises_type_error():
+    """Test Playlist class."""
+    with pytest.raises(
+        TypeError,
+        match=(
+            "Can't instantiate abstract class Playlist with abstract method"
+        ),
+    ):
+        Playlist()

--- a/tests/collection/test_base_track.py
+++ b/tests/collection/test_base_track.py
@@ -1,0 +1,13 @@
+"""Testing for the tracks module."""
+import pytest
+
+from djtools.collection.base_track import Track
+
+
+def test_track_raises_type_error():
+    """Test Track class."""
+    with pytest.raises(
+        TypeError,
+        match=("Can't instantiate abstract class Track with abstract method"),
+    ):
+        Track()

--- a/tests/collection/test_copy_playlists.py
+++ b/tests/collection/test_copy_playlists.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 import pytest
 
-from djtools.collection.collections import RekordboxCollection
 from djtools.collection.copy_playlists import copy_playlists
+from djtools.collection.rekordbox_collection import RekordboxCollection
 
 
 def test_copy_playlists_makes_destination_folder(

--- a/tests/collection/test_helpers.py
+++ b/tests/collection/test_helpers.py
@@ -7,7 +7,9 @@ from unittest import mock
 
 import pytest
 
-from djtools.collection.collections import Collection, RekordboxCollection
+from djtools.collection.base_collection import Collection
+from djtools.collection.base_playlist import Playlist
+from djtools.collection.base_track import Track
 from djtools.collection.config import PlaylistConfigContent, PlaylistName
 from djtools.collection.helpers import (
     add_selectors_to_tags,
@@ -27,8 +29,8 @@ from djtools.collection.helpers import (
     print_playlists_tag_statistics,
     scale_data,
 )
-from djtools.collection.playlists import Playlist, RekordboxPlaylist
-from djtools.collection.tracks import Track
+from djtools.collection.rekordbox_collection import RekordboxCollection
+from djtools.collection.rekordbox_playlist import RekordboxPlaylist
 
 
 # pylint: disable=duplicate-code

--- a/tests/collection/test_playlist_builder.py
+++ b/tests/collection/test_playlist_builder.py
@@ -3,12 +3,12 @@ from unittest import mock
 
 import pytest
 
-from djtools.collection.collections import RekordboxCollection
 from djtools.collection.playlist_builder import (
     collection_playlists,
     PLAYLIST_NAME,
 )
-from djtools.collection.playlists import RekordboxPlaylist
+from djtools.collection.rekordbox_collection import RekordboxCollection
+from djtools.collection.rekordbox_playlist import RekordboxPlaylist
 
 from ..test_utils import MockOpen
 
@@ -183,7 +183,7 @@ def test_collection_playlists_removes_existing_playlist(
             files=["collection_playlists.yaml"], content=f"{playlist_config}"
         ).open,
     ), mock.patch(
-        "djtools.collection.collections.RekordboxCollection.add_playlist"
+        "djtools.collection.rekordbox_collection.RekordboxCollection.add_playlist"
     ):
         collection_playlists(config, path=new_path)
 

--- a/tests/collection/test_playlist_filters.py
+++ b/tests/collection/test_playlist_filters.py
@@ -10,8 +10,8 @@ from djtools.collection.playlist_filters import (
     PlaylistFilter,
     TransitionTrackFilter,
 )
-from djtools.collection.playlists import RekordboxPlaylist
-from djtools.collection.tracks import RekordboxTrack
+from djtools.collection.rekordbox_playlist import RekordboxPlaylist
+from djtools.collection.rekordbox_track import RekordboxTrack
 
 
 def test_playlistfilter_cannot_be_instantiated():

--- a/tests/collection/test_rekordbox_collection.py
+++ b/tests/collection/test_rekordbox_collection.py
@@ -1,26 +1,13 @@
 """Testing for the collection module."""
 import bs4
-import pytest
 
-from djtools.collection.collections import (
-    Collection,
+from djtools.collection.rekordbox_collection import (
     CustomSubstitution,
     RekordboxCollection,
     UnsortedAttributes,
 )
-from djtools.collection.playlists import RekordboxPlaylist
-from djtools.collection.tracks import RekordboxTrack
-
-
-def test_collection_raises_type_error():
-    """Test Collection class."""
-    with pytest.raises(
-        TypeError,
-        match=(
-            "Can't instantiate abstract class Collection with abstract method"
-        ),
-    ):
-        Collection(path="")
+from djtools.collection.rekordbox_playlist import RekordboxPlaylist
+from djtools.collection.rekordbox_track import RekordboxTrack
 
 
 def test_rekordboxcollection_add_playlist(rekordbox_xml):

--- a/tests/collection/test_rekordbox_playlist.py
+++ b/tests/collection/test_rekordbox_playlist.py
@@ -1,18 +1,7 @@
 """Testing for the playlists module."""
 import pytest
 
-from djtools.collection.playlists import Playlist, RekordboxPlaylist
-
-
-def test_playlist_raises_type_error():
-    """Test Playlist class."""
-    with pytest.raises(
-        TypeError,
-        match=(
-            "Can't instantiate abstract class Playlist with abstract method"
-        ),
-    ):
-        Playlist()
+from djtools.collection.rekordbox_playlist import RekordboxPlaylist
 
 
 def test_rekordboxplaylist_getitem(rekordbox_playlist):

--- a/tests/collection/test_rekordbox_track.py
+++ b/tests/collection/test_rekordbox_track.py
@@ -4,16 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from djtools.collection.tracks import Track, RekordboxTrack
-
-
-def test_track_raises_type_error():
-    """Test Track class."""
-    with pytest.raises(
-        TypeError,
-        match=("Can't instantiate abstract class Track with abstract method"),
-    ):
-        Track()
+from djtools.collection.rekordbox_track import RekordboxTrack
 
 
 @pytest.mark.parametrize(

--- a/tests/collection/test_shuffle_playlists.py
+++ b/tests/collection/test_shuffle_playlists.py
@@ -1,9 +1,9 @@
 """Testing for the shuffle_playlists module."""
 import pytest
 
-from djtools.collection.collections import RekordboxCollection
+from djtools.collection.base_playlist import Playlist
+from djtools.collection.rekordbox_collection import RekordboxCollection
 from djtools.collection.shuffle_playlists import shuffle_playlists
-from djtools.collection.playlists import Playlist
 
 
 def test_shuffle_playlists_handles_missing_playlist(config, rekordbox_xml):

--- a/tests/sync/test_helpers.py
+++ b/tests/sync/test_helpers.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest
 
-from djtools.collection.collections import RekordboxCollection
+from djtools.collection.rekordbox_collection import RekordboxCollection
 from djtools.sync.helpers import (
     parse_sync_command,
     rewrite_track_paths,


### PR DESCRIPTION
Why?
When support for platforms other than Rekordbox is added, the pre-existing modules for Collections, Playlists, and Tracks will quickly become too verbose.

What?
Split abstract base classes and Rekordbox implementations into their own modules.