### PR TITLE
feat: support timedeltas in playlist_builder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "pydantic",
     "pydub",
     "pyperclip",
+    "python-dateutil",
     "PyYAML",
     "requests",
     "spotipy",


### PR DESCRIPTION
Why?
Users may want to maintain a "Recent Tracks" style of playlists.

What?
This builds on the string selector feature by adding additional processing of date selector types.
More specifically, if a date selector includes an inequality, before trying to convert the next part of the expression into a datetime, we first try and convert it into a 'ymwd' (year, month, week, day) timedelta and return a datetime offset by that timedelta instead.