### PR TITLE
Releases/2.7.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Please see the [docs](https://a-rich.github.io/DJ-Tools/) for tutorials, how-to guides, conceptual guides, and references!
 
 # Release Plan
-* 2.7.14
+* 2.7.15
     - [ ] [Stability issues with requests to the search endpoint of the Spotify API](https://github.com/a-rich/DJ-Tools/issues/58)
     - [ ] [Make Spotify API calls asynchronous](https://github.com/a-rich/DJ-Tools/issues/38)
 * 2.8.0

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 """This module contains fixtures for DJ Tools."""
+
 from argparse import Namespace
 import os
 from pathlib import Path

--- a/docs/how_to_guides/combiner_playlists.md
+++ b/docs/how_to_guides/combiner_playlists.md
@@ -50,6 +50,9 @@ The `Combiner` solves all these issues in the following ways:
     - `{date:2022}`
     - `{date:>2021-10-05}`
     - `{date:<=2020-05}`
+    - `{date:1y}`
+    - `{date:>=3m}`
+    - `{date:<10w5d}`
     - `{key:7A}`
     - `{label:duploc}`
     - `{playlist: Deep House}`
@@ -64,7 +67,19 @@ The `Combiner` solves all these issues in the following ways:
     - `(`
     - `)`
 
-Let's look at an example playlist to see how the syntax works.
+### Date string selectors can take two forms:
+1. ISO format date strings e.g. `2024-06-22`, `2024-06`, `2024`
+2. `ymwd` (year, month, week, day) format timedelta strings e.g. `1y`, `3m2w`, `5d`
+
+Here's how playlists can be built using the different date string selector types using the examples from above.
+- `{date:2022}`: tracks added in the year 2022
+- `{date:>2021-10-05}`: track added after October 5th, 2021
+- `{date:<=2020-05}`: tracks added on or before May, 2020
+- `{date:1y}`: tracks added exactly 1 year ago today
+- `{date:>=3m}`: tracks added within the last 3 months
+- `{date:<10w5d}`: tracks at least 75 days old
+
+### Let's look at an example playlist to see how the syntax works.
 
 Suppose we want a playlist with tracks that _all have_ the following properties:
 

--- a/docs/how_to_guides/setup_object_storage.md
+++ b/docs/how_to_guides/setup_object_storage.md
@@ -18,7 +18,6 @@ There are two primary reasons to sync your files to the cloud:
 &nbsp;&nbsp;&nbsp;`msiexec.exe /i https://awscli.amazonaws.com/AWSCLIV2.msi`
 
 1. [Create and setup an account for AWS S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/GetStartedWithS3.html) (you could use any AWS S3 API compliant cloud storage solution, e.g. [MinIO](https://min.io/), but I've not tested anything else)
-1. At the time of writing, it's required that your bucket has the address `dj.beatcloud.com`
 1. Setup a profile (so as to not conflict with pre-existing or future profiles) for your keys:
 
     &nbsp;&nbsp;&nbsp;`aws configure --profile DJ`

--- a/docs/how_to_guides/sync_beatcloud.md
+++ b/docs/how_to_guides/sync_beatcloud.md
@@ -41,7 +41,7 @@ Syncing your database files also improves reliability since you may lose, damage
 
 ### Downloading collection
 1. Set the `IMPORT_USER` option to the username of another user in your Beatcloud
-    - This username must exist as a directory in the Beatcloud under `dj.beatcloud.com/collections` (it will if this user has ever run `--upload-collection`)
+    - This username must exist as a directory in the Beatcloud under `<BUCKET_URL>/collections` (it will if this user has ever run `--upload-collection`)
 1. Run the command `djtools --download-collection`
 
 `Note`: you can set `IMPORT_USER` to your own `USER` value to retrieve a backup of your collection.

--- a/docs/tutorials/getting_started/configuration.md
+++ b/docs/tutorials/getting_started/configuration.md
@@ -70,5 +70,5 @@ If `config.yaml` contains any unsupported options, `djtools` will fail as extra 
 * `PROCESS_RECORDING`: boolean flag to trigger processing an audio recording using a Spotify playlist
 * `RECORDING_FILE`: Audio recording to pair with `RECORDING_PLAYLIST`
 * `RECORDING_PLAYLIST`: Spotify playlist to pair with `RECORDING_FILE`
-* `SKIP_TRIM_INITIAL_SILENCE`: Flag to skip trimming initial silence of `RECORDING_FILE`
+* `TRIM_INITIAL_SILENCE`: Milliseconds of initial silence to trim off `RECORDING_FILE`. Can also be a negative integer to prepend silence. Can also be "auto" or "smart" for automatic silence detection or a home-brewed algorithm for finding the optimal offset.
 * `URL_DOWNLOAD`: URL from which music files should be downloaded (i.e. a Soundcloud playlist)

--- a/docs/tutorials/getting_started/configuration.md
+++ b/docs/tutorials/getting_started/configuration.md
@@ -41,6 +41,7 @@ If `config.yaml` contains any unsupported options, `djtools` will fail as extra 
 ## [Sync config][djtools.sync.config.SyncConfig]
 * `AWS_PROFILE`: the name of the profile used when running `aws configure --profile`
 * `AWS_USE_DATE_MODIFIED`: up/download files that already exist at the destination if the date modified field at the source is after that of the destination...BE SURE THAT ALL USERS OF YOUR `BEATCLOUD` INSTANCE ARE ON BOARD BEFORE UPLOADING WITH THIS FLAG SET!
+* `BUCKET_URL`: URL for an AWS S3 API compliant storage location
 * `DISCORD_URL`: webhook URL for messaging a Discord server's channel when new music has been uploaded to the `beatcloud`
 * `DOWNLOAD_COLLECTION`: sync the collection of `IMPORT_USER` from the `beatcloud` to the directory that `COLLECTION_PATH` is in
 * `DOWNLOAD_EXCLUDE_DIRS`: the list of paths (relative to the `DJ Music` folder on your `USB_PATH`) that should NOT be downloaded from the `beatcloud` when running the `download_music` sync operation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "djtools"
-version = "2.7.13"
+version = "2.7.14"
 authors = [
     {name = "Alex Richards", email = "alex.richards006@gmail.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "djtools"
-version = "2.7.14-rc3"
+version = "2.7.14-rc4"
 authors = [
     {name = "Alex Richards", email = "alex.richards006@gmail.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "djtools"
-version = "2.7.14"
+version = "2.7.14-rc.1"
 authors = [
     {name = "Alex Richards", email = "alex.richards006@gmail.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "djtools"
-version = "2.7.14-rc4"
+version = "2.7.14-rc5"
 authors = [
     {name = "Alex Richards", email = "alex.richards006@gmail.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "djtools"
-version = "2.7.14-rc5"
+version = "2.7.14-rc6"
 authors = [
     {name = "Alex Richards", email = "alex.richards006@gmail.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "djtools"
-version = "2.7.14-rc2"
+version = "2.7.14-rc3"
 authors = [
     {name = "Alex Richards", email = "alex.richards006@gmail.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "djtools"
-version = "2.7.14-rc6"
+version = "2.7.14-rc7"
 authors = [
     {name = "Alex Richards", email = "alex.richards006@gmail.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "djtools"
-version = "2.7.14-rc.1"
+version = "2.7.14-rc2"
 authors = [
     {name = "Alex Richards", email = "alex.richards006@gmail.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "pydantic",
     "pydub",
     "pyperclip",
+    "python-dateutil",
     "PyYAML",
     "requests",
     "spotipy",

--- a/scripts/collection/cluster_tracks.py
+++ b/scripts/collection/cluster_tracks.py
@@ -1,4 +1,5 @@
 """Cluster tracks by tags."""
+
 # pylint: disable=import-error,redefined-outer-name,duplicate-code
 from argparse import ArgumentParser
 from pathlib import Path

--- a/scripts/collection/get_tags_from_spotify.py
+++ b/scripts/collection/get_tags_from_spotify.py
@@ -7,11 +7,14 @@ the year, album, and label.
 from argparse import ArgumentParser
 from concurrent.futures import as_completed, ThreadPoolExecutor
 from datetime import datetime
+from itertools import groupby
 import os
+from typing import Dict, Union
 
 from tqdm import tqdm
 
 from djtools.configs.helpers import build_config
+from djtools.collection.base_track import Track
 from djtools.collection.helpers import PLATFORM_REGISTRY
 from djtools.spotify.helpers import filter_results, get_spotify_client
 
@@ -49,10 +52,71 @@ def get_spotify_tags_thread(track, spotify, threshold, query_limit):
             setattr(track, f"_{attribute_name.title()}", attribute)
 
 
+def convert_to_datetime(arg: str) -> Union[datetime, str]:
+    """Convert string to datetime.
+
+    Args:
+        arg: datetime as a YYYY-MM-DD string
+
+    Returns:
+        Either the datetime object to filter after or a string indicating that
+            the most recent upload should be filtered.
+    """
+    if arg == "most-recent":
+        return arg
+
+    try:
+        return datetime.strptime(arg, "%Y-%m-%d")
+    except ValueError as exc:
+        raise ValueError(
+            f"Couldn't convert --date-filter argument '{arg}' into a datetime."
+        ) from exc
+
+
+def filter_tracks(
+    tracks: Dict[str, Track], date_filter: Union[datetime, str]
+) -> Dict[str, Track]:
+    """Filter tracks using a date filter.
+
+    Args:
+        tracks: Dictionary of tracks to filter.
+        date_filter: datetime to filter tracks with.
+
+    Returns:
+        Dictionary of filtered tracks.
+    """
+    if date_filter == "all":
+        return tracks
+
+    sorted_tracks = sorted(tracks.values(), key=lambda x: x.get_date_added())
+
+    if date_filter == "most-recent":
+        date_filter = sorted_tracks[-1].get_date_added()
+
+    filtered_tracks = []
+    for date, track_list in groupby(
+        sorted_tracks, key=lambda x: x.get_date_added()
+    ):
+        if date < date_filter:
+            continue
+        filtered_tracks.extend(list(track_list))
+
+    return {track.get_id(): track for track in filtered_tracks}
+
+
 if __name__ == "__main__":
     arg_parser = ArgumentParser()
     arg_parser.add_argument("--collection", help="Path to a collection.")
     arg_parser.add_argument("--config", help="Path to a config.yaml.")
+    arg_parser.add_argument(
+        "--date-filter",
+        type=convert_to_datetime,
+        default="most-recent",
+        help=(
+            "Datetime to after which tracks should have tags added from "
+            "Spotify. Default is 'most-recent'."
+        ),
+    )
     arg_parser.add_argument(
         "--mode",
         choices=["bulk", "interactive"],
@@ -79,7 +143,7 @@ if __name__ == "__main__":
     collection = PLATFORM_REGISTRY[config.PLATFORM]["collection"](
         path=args.collection or config.COLLECTION_PATH
     )
-    tracks = collection.get_tracks()
+    tracks = filter_tracks(collection.get_tracks(), args.date_filter)
     spotify = get_spotify_client(config)
     playlist_class = PLATFORM_REGISTRY[config.PLATFORM]["playlist"]
 

--- a/scripts/collection/move_tags.py
+++ b/scripts/collection/move_tags.py
@@ -5,6 +5,7 @@ Supported functions include:
 * moving particular tags from the `Comments` field to the `Genre` field
 * moving particular tags from in the `Comments` field to the front of that field
 """
+
 from argparse import ArgumentParser
 from pathlib import Path
 import re

--- a/scripts/collection/remove_tags_from_comments.py
+++ b/scripts/collection/remove_tags_from_comments.py
@@ -5,6 +5,7 @@ the year, album, and label. In addition, it removes "situation" tags
 {"Opener", "Build", "Peak Time"} from the Comments field. This is done because
 I'm now re-purposing the "Rating" field to convey the energy level of tracks.
 """
+
 # pylint: disable=redefined-outer-name,duplicate-code
 from argparse import ArgumentParser
 from concurrent.futures import as_completed, ThreadPoolExecutor

--- a/scripts/collection/sort_tags.py
+++ b/scripts/collection/sort_tags.py
@@ -1,6 +1,7 @@
 """This is a script for sorting the non-genre tags of a collection in
 alphabetical order.
 """
+
 # pylint: disable=protected-access
 from argparse import ArgumentParser
 import re

--- a/scripts/collection/tracks_outside_playlists.py
+++ b/scripts/collection/tracks_outside_playlists.py
@@ -2,6 +2,7 @@
 not appear in a given playlist (or, if using '--folder', any playlists in a
 folder).
 """
+
 from argparse import ArgumentParser
 import logging
 from traceback import format_exc

--- a/scripts/collection/update_collection.py
+++ b/scripts/collection/update_collection.py
@@ -1,4 +1,5 @@
 """Update master track Collection with local Collection."""
+
 # pylint: disable=duplicate-code
 from argparse import ArgumentParser
 from itertools import groupby

--- a/scripts/collection/update_collection.py
+++ b/scripts/collection/update_collection.py
@@ -70,12 +70,12 @@ if __name__ == "__main__":
 
     # Set the path to the remote master collection either from the CLI arg or
     # dynamically. The default path is:
-    # s3://dj.beatcloud.com/dj/collections/master/rekordbox_collection
+    # <BUCKET-URL>/dj/collections/master/rekordbox_collection
     if args.master_collection:
         remote_master_collection = args.master_collection
     else:
         remote_master_collection = (
-            "s3://dj.beatcloud.com/dj/collections/"
+            f"{config.BUCKET_URL}/dj/collections/"
             f"{args.master_collection_user}/{config.PLATFORM}_collection"
         )
 

--- a/scripts/collection/update_collection.py
+++ b/scripts/collection/update_collection.py
@@ -20,8 +20,14 @@ if __name__ == "__main__":
     )
     arg_parser.add_argument(
         "--master-collection",
-        required=True,
+        required=False,
         help="Path to a remote master collection.",
+    )
+    arg_parser.add_argument(
+        "--master-collection-user",
+        required=False,
+        default="master",
+        help="Username for remote master collection.",
     )
     arg_parser.add_argument(
         "--overwrite",
@@ -62,9 +68,20 @@ if __name__ == "__main__":
         for _, track in collection.get_tracks().items()
     }
 
+    # Set the path to the remote master collection either from the CLI arg or
+    # dynamically. The default path is:
+    # s3://dj.beatcloud.com/dj/collections/master/rekordbox_collection
+    if args.master_collection:
+        remote_master_collection = args.master_collection
+    else:
+        remote_master_collection = (
+            "s3://dj.beatcloud.com/dj/collections/"
+            f"{args.master_collection_user}/{config.PLATFORM}_collection"
+        )
+
     # Download the master collection and get a dict of its tracks too.
     master_collection_path = Path("master_collection.tmp")
-    cmd = ["aws", "s3", "cp", args.master_collection, master_collection_path]
+    cmd = ["aws", "s3", "cp", remote_master_collection, master_collection_path]
     if collection_path.is_dir():
         cmd.append("--recursive")
     with Popen(cmd) as proc:
@@ -128,7 +145,7 @@ if __name__ == "__main__":
             "s3",
             "cp",
             master_collection_path,
-            args.master_collection,
+            remote_master_collection,
         ]
         if collection_path.is_dir():
             cmd.append("--recursive")

--- a/scripts/collection/user_vibe_analysis.py
+++ b/scripts/collection/user_vibe_analysis.py
@@ -1,4 +1,5 @@
 """This script is used to generate histograms of My Tags per user."""
+
 # pylint: disable=import-error,redefined-outer-name,unused-argument,invalid-name
 from argparse import ArgumentParser
 from collections import defaultdict

--- a/scripts/repair/move_music_new_structure.py
+++ b/scripts/repair/move_music_new_structure.py
@@ -1,6 +1,7 @@
 """Script used to relocate all music files from the old genre-top-level
 structure to the new username-top-level structure.
 """
+
 # pylint: disable=too-many-arguments,duplicate-code,no-member
 from argparse import ArgumentParser
 from concurrent.futures import ThreadPoolExecutor

--- a/scripts/repair/normalize_audio.py
+++ b/scripts/repair/normalize_audio.py
@@ -1,6 +1,7 @@
 """This module is a script for normalizing the audio to have a peak amplitude
 of 0.0 decibels.
 """
+
 # pylint: disable=import-error
 from argparse import ArgumentParser
 from collections import defaultdict

--- a/scripts/repair/rename_files.py
+++ b/scripts/repair/rename_files.py
@@ -75,6 +75,7 @@ the common path of tracks in your collection:
         --path-insert "" \
         --infer-file-names
 """
+
 # pylint: disable=import-error,redefined-outer-name,no-member
 from argparse import ArgumentParser
 from concurrent.futures import as_completed, ThreadPoolExecutor

--- a/scripts/repair/swap_title_artist.py
+++ b/scripts/repair/swap_title_artist.py
@@ -46,6 +46,7 @@ correct Location field, you can set your import XML to be this one and import
 the tracks in this missing files playlist into your collection to relocate them
 while retaining the original beatgrid, hot cues, etc.
 """
+
 # pylint: disable=import-error,no-member
 from argparse import ArgumentParser
 from datetime import datetime

--- a/scripts/testing/parse_pytest_output.py
+++ b/scripts/testing/parse_pytest_output.py
@@ -1,4 +1,5 @@
 """Script for analyzing timing of unit tests and fixtures."""
+
 # pylint: disable=import-error
 from collections import defaultdict
 from itertools import groupby

--- a/src/djtools/__init__.py
+++ b/src/djtools/__init__.py
@@ -8,6 +8,7 @@ operations of the library and calls the corresponding function with the
 appropriate configuration object. Finally, the log file generated from this run
 is uploaded to the Beatcloud.
 """
+
 from .configs import build_config
 from .collection import (
     COLLECTION_OPERATIONS,

--- a/src/djtools/collection/base_collection.py
+++ b/src/djtools/collection/base_collection.py
@@ -5,6 +5,7 @@ Collection is an abstract base class which defines the interface expected of a
 collection; namely methods for (de)serialization to/from the representation
 recognized by the DJ software for which Collection is being sub-classed.
 """
+
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from pathlib import Path

--- a/src/djtools/collection/base_playlist.py
+++ b/src/djtools/collection/base_playlist.py
@@ -5,6 +5,7 @@ Playlist is an abstract base class which defines the interface expected of a
 playlist; namely methods for (de)serialization to/from the representation
 recognized by the DJ software for which Playlist is being sub-classed.
 """
+
 from __future__ import annotations
 from abc import ABC, abstractmethod
 import re

--- a/src/djtools/collection/base_track.py
+++ b/src/djtools/collection/base_track.py
@@ -5,6 +5,7 @@ Track is an abstract base class which defines the interface expected of a
 track; namely methods for (de)serialization to/from the representation
 recognized by the DJ software for which Track is being sub-classed.
 """
+
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from pathlib import Path

--- a/src/djtools/collection/config.py
+++ b/src/djtools/collection/config.py
@@ -2,6 +2,7 @@
 The attributes of this configuration object correspond with the "collection"
 key of config.yaml
 """
+
 from __future__ import annotations
 import logging
 from pathlib import Path

--- a/src/djtools/collection/copy_playlists.py
+++ b/src/djtools/collection/copy_playlists.py
@@ -7,6 +7,7 @@ The purpose of this utility is to:
 * backup subsets of your library
 * ensure you have easy access to a preparation independent of the setup
 """
+
 # pylint: disable=duplicate-code
 from collections import defaultdict
 from concurrent.futures import as_completed, ThreadPoolExecutor

--- a/src/djtools/collection/helpers.py
+++ b/src/djtools/collection/helpers.py
@@ -542,17 +542,16 @@ def parse_string_selectors(
         for part in filter(
             None, re.split(DATE_SELECTOR_REGEX, selector_value)
         ):
+            date = None
+            date_format = "%Y-%m-%d"
+
             # Note if the part is an inequality and move onto the next part.
             if re.search(DATE_SELECTOR_REGEX, part):
                 inequalities.append(INEQUALITY_MAP[part])
                 continue
 
-            # If a former part was an inequality, then the following part may
-            # be a timedelta string...
-            date = None
-            if inequalities:
-                date = parse_timedelta(part)
-                date_format = "%Y-%m-%d"
+            # The following part may be a timedelta string...
+            date = parse_timedelta(part)
 
             # ...but if it wasn't, it's probably an ISO format date string.
             if not date:

--- a/src/djtools/collection/helpers.py
+++ b/src/djtools/collection/helpers.py
@@ -1,4 +1,5 @@
 """This module contains helpers for the collection package."""
+
 from __future__ import annotations
 from collections import defaultdict
 from datetime import datetime
@@ -489,9 +490,9 @@ def parse_numerical_selectors(
             logger.error(f"Malformed numerical selector: {match}")
             continue
 
-        numerical_value_lookup[
-            tuple(map(str, _range or [])) or match
-        ] = f"[{match}]"
+        numerical_value_lookup[tuple(map(str, _range or [])) or match] = (
+            f"[{match}]"
+        )
 
     return numerical_values
 
@@ -522,9 +523,9 @@ def parse_string_selectors(
             logger.warning(f"{selector_type} is not a supported selector!")
             continue
         if selector_type != "date":
-            string_value_lookup[
-                (selector_type, selector_value)
-            ] = f"{{{match}}}"
+            string_value_lookup[(selector_type, selector_value)] = (
+                f"{{{match}}}"
+            )
             continue
 
         dates, formats, inequalities = [], [], []

--- a/src/djtools/collection/playlist_filters.py
+++ b/src/djtools/collection/playlist_filters.py
@@ -10,6 +10,7 @@ The 'is_filter_playlist' method, when given a 'Playlist', returns true if that
 The 'filter_track' method, when given a 'Track', returns true if that 'Track'
 should remain in the playlist.
 """
+
 from abc import ABC, abstractmethod
 import re
 from typing import List, Optional

--- a/src/djtools/collection/rekordbox_collection.py
+++ b/src/djtools/collection/rekordbox_collection.py
@@ -4,6 +4,7 @@ RekordboxCollection is an implementation of Collection which operates on the
 XML format that Rekordbox exports. The CustomSubstitution and
 UnsortedAttributes classes are helpers for serializing a RekordboxCollection.
 """
+
 from __future__ import annotations
 from copy import copy
 from pathlib import Path

--- a/src/djtools/collection/rekordbox_playlist.py
+++ b/src/djtools/collection/rekordbox_playlist.py
@@ -3,6 +3,7 @@
 RekordboxPlaylist is an implementation of Playlist which operates on the XML
 format that Rekordbox exports.
 """
+
 from __future__ import annotations
 import inspect
 from pathlib import Path

--- a/src/djtools/collection/rekordbox_track.py
+++ b/src/djtools/collection/rekordbox_track.py
@@ -3,6 +3,7 @@
 RekordboxTrack is an implementation of Track which operates on the XML format
 that Rekordbox exports.
 """
+
 from __future__ import annotations
 from datetime import datetime
 import os

--- a/src/djtools/collection/shuffle_playlists.py
+++ b/src/djtools/collection/shuffle_playlists.py
@@ -3,6 +3,7 @@ playlists. This is done by setting the track number attribute of each track in
 sequential order after collecting the set of Tracks from the provided
 playlist(s).
 """
+
 from concurrent.futures import as_completed, ThreadPoolExecutor
 import logging
 import os

--- a/src/djtools/configs/__init__.py
+++ b/src/djtools/configs/__init__.py
@@ -6,6 +6,7 @@
     * `helpers`: contains functions for building configuration objects and
         parsing command-line arguments
 """
+
 from djtools.configs.helpers import build_config
 
 

--- a/src/djtools/configs/cli_args.py
+++ b/src/djtools/configs/cli_args.py
@@ -268,6 +268,11 @@ def get_arg_parser() -> ArgumentParser:
         ),
     )
     sync_parser.add_argument(
+        "--bucket-url",
+        type=str,
+        help="URL for an AWS S3 API compliant bucket.",
+    )
+    sync_parser.add_argument(
         "--discord-url",
         type=str,
         help="Discord webhook URL used to post uploaded tracks.",

--- a/src/djtools/configs/cli_args.py
+++ b/src/djtools/configs/cli_args.py
@@ -1,10 +1,11 @@
 """This module is responsible for creating the argparse.NameSpace object from
 the CLI args.
 """
+
 from argparse import Action, ArgumentParser, Namespace, RawTextHelpFormatter
 import json
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 
 
 def get_arg_parser() -> ArgumentParser:
@@ -468,9 +469,15 @@ def get_arg_parser() -> ArgumentParser:
         help='Spotify playlist to pair with "--recording-file".',
     )
     utils_parser.add_argument(
-        "--skip-trim-initial-silence",
-        action="store_true",
-        help='Flag to skip trimming initial silence of "--recording-file".',
+        "--trim-initial-silence",
+        type=_parse_trim_initial_silence,
+        default=0,
+        help=(
+            'Milliseconds of initial silence to trim off "--recording-file". '
+            "Can also be a negative integer to prepend silence. Can also be "
+            '"auto" or "smart" for automatic silence detection or a '
+            "home-brewed algorithm for finding the optimal offset."
+        ),
     )
     utils_parser.add_argument(
         "--url-download",
@@ -545,3 +552,19 @@ def _parse_json(_json: str) -> Dict:
         raise ValueError(
             f'Unable to parse JSON type argument "{_json}": {exc}'
         ) from Exception
+
+
+def _parse_trim_initial_silence(
+    arg: str,
+) -> Union[int, Literal["auto", "smart"]]:
+    if arg in {"auto", "smart"}:
+        return arg
+
+    try:
+        arg = int(arg)
+    except Exception as exc:
+        raise ValueError(
+            '--trim-initial-silence must be either "auto", "smart", or an integer.'
+        ) from exc
+
+    return arg

--- a/src/djtools/configs/config.py
+++ b/src/djtools/configs/config.py
@@ -2,6 +2,7 @@
 this configuration object either don't apply to any particular package or they
 apply to multiple packages. The attributes of this configuration object
 correspond with the "configs" key of config.yaml."""
+
 import inspect
 import logging
 from typing_extensions import Literal
@@ -16,9 +17,9 @@ class BaseConfig(BaseModel, extra="allow"):
     """Base configuration object used across the whole library."""
 
     ARTIST_FIRST: bool = False
-    LOG_LEVEL: Literal[
-        "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
-    ] = "INFO"
+    LOG_LEVEL: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = (
+        "INFO"
+    )
     VERBOSITY: NonNegativeInt = 0
 
     def __init__(self, *args, **kwargs):

--- a/src/djtools/configs/helpers.py
+++ b/src/djtools/configs/helpers.py
@@ -2,6 +2,7 @@
 using config.yaml. If command-line arguments are provided, this module
 overrides the corresponding configuration options with these arguments.
 """
+
 import inspect
 import logging
 from pathlib import Path

--- a/src/djtools/spotify/__init__.py
+++ b/src/djtools/spotify/__init__.py
@@ -4,6 +4,7 @@
     * `playlist_builder`: constructs or updates Spotify playlists using either
         Subreddit posts or the Discord webhook output from `UPLOAD_MUSIC`
 """
+
 from djtools.spotify.playlist_builder import (
     spotify_playlist_from_upload,
     spotify_playlists,

--- a/src/djtools/spotify/config.py
+++ b/src/djtools/spotify/config.py
@@ -2,6 +2,7 @@
 The attributes of this configuration object correspond with the "spotify" key
 of config.yaml
 """
+
 import logging
 from typing import List
 from typing_extensions import Literal

--- a/src/djtools/spotify/helpers.py
+++ b/src/djtools/spotify/helpers.py
@@ -1,4 +1,5 @@
 """This module contains helper functions used by the "spotify" module."""
+
 from concurrent.futures import as_completed, ThreadPoolExecutor
 import logging
 from operator import itemgetter

--- a/src/djtools/spotify/playlist_builder.py
+++ b/src/djtools/spotify/playlist_builder.py
@@ -14,6 +14,7 @@ are then used to search the Spotify API for tracks. The resulting tracks have
 their title and artist fields compared with the reddit post title and are added
 to the respective playlist if the Levenshtein similarity passes a threshold.
 """
+
 import asyncio
 import logging
 from pathlib import Path

--- a/src/djtools/sync/__init__.py
+++ b/src/djtools/sync/__init__.py
@@ -4,6 +4,7 @@
     * `sync_operations`: for syncing audio and collection files to the
         Beatcloud
 """
+
 from djtools.sync.sync_operations import (
     download_collection,
     download_music,

--- a/src/djtools/sync/config.py
+++ b/src/djtools/sync/config.py
@@ -77,9 +77,9 @@ class SyncConfig(BaseConfig):
                 logger.critical(msg)
                 raise RuntimeError(msg)
 
-        os.environ["AWS_PROFILE"] = (  # pylint: disable=no-member
+        os.environ["AWS_PROFILE"] = (
             self.AWS_PROFILE
-        )
+        )  # pylint: disable=no-member
 
         if any([self.DOWNLOAD_MUSIC, self.UPLOAD_MUSIC]) and not self.USB_PATH:
             msg = (

--- a/src/djtools/sync/config.py
+++ b/src/djtools/sync/config.py
@@ -19,6 +19,7 @@ class SyncConfig(BaseConfig):
 
     AWS_PROFILE: str = "default"
     AWS_USE_DATE_MODIFIED: bool = False
+    BUCKET_URL: str = ""
     DISCORD_URL: str = ""
     DOWNLOAD_COLLECTION: bool = False
     DOWNLOAD_EXCLUDE_DIRS: List[Path] = []
@@ -67,6 +68,11 @@ class SyncConfig(BaseConfig):
         ):
             if not self.AWS_PROFILE:
                 msg = "Config must include AWS_PROFILE for sync operations"
+                logger.critical(msg)
+                raise RuntimeError(msg)
+
+            if not self.BUCKET_URL:
+                msg = "Config must include BUCKET_URL for sync operations"
                 logger.critical(msg)
                 raise RuntimeError(msg)
 

--- a/src/djtools/sync/config.py
+++ b/src/djtools/sync/config.py
@@ -2,6 +2,7 @@
 The attributes of this configuration object correspond with the "sync" key
 of config.yaml
 """
+
 import getpass
 import logging
 import os
@@ -76,9 +77,9 @@ class SyncConfig(BaseConfig):
                 logger.critical(msg)
                 raise RuntimeError(msg)
 
-        os.environ[  # pylint: disable=no-member
-            "AWS_PROFILE"
-        ] = self.AWS_PROFILE
+        os.environ["AWS_PROFILE"] = (  # pylint: disable=no-member
+            self.AWS_PROFILE
+        )
 
         if any([self.DOWNLOAD_MUSIC, self.UPLOAD_MUSIC]) and not self.USB_PATH:
             msg = (

--- a/src/djtools/sync/helpers.py
+++ b/src/djtools/sync/helpers.py
@@ -3,6 +3,7 @@ Helper functions include formatting "aws s3 sync" commands, formatting the
 output of "aws s3 sync" commands, posting uploaded tracks to Discord, and
 modifying IMPORT_USER's collection to point to tracks located at "USB_PATH".
 """
+
 from datetime import datetime, timedelta
 from itertools import groupby
 import logging

--- a/src/djtools/sync/helpers.py
+++ b/src/djtools/sync/helpers.py
@@ -106,12 +106,13 @@ def rewrite_track_paths(config: BaseConfig, other_user_collection: Path):
     collection.serialize(path=other_user_collection)
 
 
-def run_sync(_cmd: str) -> str:
+def run_sync(_cmd: str, bucket_url: str) -> str:
     """Runs subprocess for "aws s3 sync" command. Output is collected and
         formatted such that uploaded tracks are grouped by their directories.
 
     Args:
         _cmd: "aws s3 sync" command.
+        bucket_url: URL to an AWS S3 API compliant bucket.
 
     Raises:
         CalledProcessError: raised if "aws s3 sync" command fails.
@@ -137,7 +138,7 @@ def run_sync(_cmd: str) -> str:
                     continue
                 print(line, end=char)
                 if char != "\r" and "upload: " in line:
-                    line = line.split("s3://dj.beatcloud.com/dj/music/")[-1]
+                    line = line.split(f"{bucket_url}/dj/music/")[-1]
                     tracks.append(Path(line))
                 line = ""
             proc.stdout.close()
@@ -182,7 +183,7 @@ def upload_log(config: BaseConfig, log_file: Path):
         )
         return
 
-    dst = f"s3://dj.beatcloud.com/dj/logs/{config.USER}/{log_file.name}"
+    dst = f"{config.BUCKET_URL}/dj/logs/{config.USER}/{log_file.name}"
     cmd = ["aws", "s3", "cp", log_file.as_posix(), dst]
     logger.info(" ".join(cmd))
     with Popen(cmd) as proc:

--- a/src/djtools/sync/sync_operations.py
+++ b/src/djtools/sync/sync_operations.py
@@ -65,10 +65,10 @@ def download_music(
         "aws",
         "s3",
         "sync",
-        "s3://dj.beatcloud.com/dj/music/",
+        f"{config.BUCKET_URL}/dj/music/",
         dest.as_posix(),
     ]
-    run_sync(parse_sync_command(cmd, config))
+    run_sync(parse_sync_command(cmd, config), config.BUCKET_URL)
 
     new = {str(p) for p in dest.rglob(glob_path)}
     difference = sorted(list(new.difference(old)), key=getmtime)
@@ -94,7 +94,7 @@ def download_collection(config: BaseConfig):
     )
     collection_dir = config.COLLECTION_PATH.parent
     src = (
-        f"s3://dj.beatcloud.com/dj/collections/{config.IMPORT_USER}/"
+        f"{config.BUCKET_URL}/dj/collections/{config.IMPORT_USER}/"
         f"{config.PLATFORM}_collection"
     )
     dst = (
@@ -134,15 +134,19 @@ def upload_music(config: BaseConfig):
 
     logger.info("Uploading track collection...")
     src = (Path(config.USB_PATH) / "DJ Music").as_posix()
-    cmd = ["aws", "s3", "sync", src, "s3://dj.beatcloud.com/dj/music/"]
+    cmd = ["aws", "s3", "sync", src, f"{config.BUCKET_URL}/dj/music/"]
 
     if config.DISCORD_URL and not config.DRYRUN:
         webhook(
             config.DISCORD_URL,
-            content=run_sync(parse_sync_command(cmd, config, upload=True)),
+            content=run_sync(
+                parse_sync_command(cmd, config, upload=True), config.BUCKET_URL
+            ),
         )
     else:
-        run_sync(parse_sync_command(cmd, config, upload=True))
+        run_sync(
+            parse_sync_command(cmd, config, upload=True), config.BUCKET_URL
+        )
 
 
 def upload_collection(config: BaseConfig):
@@ -153,7 +157,7 @@ def upload_collection(config: BaseConfig):
     """
     logger.info(f"Uploading {config.USER}'s {config.PLATFORM} collection...")
     dst = (
-        f"s3://dj.beatcloud.com/dj/collections/{config.USER}/"
+        f"{config.BUCKET_URL}/dj/collections/{config.USER}/"
         f"{config.PLATFORM}_collection"
     )
     cmd = ["aws", "s3", "cp", config.COLLECTION_PATH.as_posix(), dst]

--- a/src/djtools/sync/sync_operations.py
+++ b/src/djtools/sync/sync_operations.py
@@ -4,6 +4,7 @@ located at "COLLECTION_PATH" and downloading the collection uploaded to the
 Beatcloud by "IMPORT_USER" before modifying it to point to track locations at
 "USB_PATH".
 """
+
 import logging
 from os.path import getmtime
 from pathlib import Path

--- a/src/djtools/utils/__init__.py
+++ b/src/djtools/utils/__init__.py
@@ -12,6 +12,7 @@
         bit rate and file format.
     * `url_download`: download tracks from a URL (e.g. Soundcloud playlist).
 """
+
 from djtools.utils.check_tracks import compare_tracks
 from djtools.utils.normalize_audio import normalize
 from djtools.utils.process_recording import process

--- a/src/djtools/utils/check_tracks.py
+++ b/src/djtools/utils/check_tracks.py
@@ -1,6 +1,7 @@
 """This module is used to compare tracks from Spotify playlists and / or local
 directories to see if there is any overlap with the contents of the Beatcloud.
 """
+
 from collections import defaultdict
 from itertools import groupby
 import logging

--- a/src/djtools/utils/check_tracks.py
+++ b/src/djtools/utils/check_tracks.py
@@ -96,7 +96,7 @@ def compare_tracks(
         return beatcloud_tracks, beatcloud_matches
 
     if not beatcloud_tracks:
-        beatcloud_tracks = get_beatcloud_tracks()
+        beatcloud_tracks = get_beatcloud_tracks(config.BUCKET_URL)
 
     path_lookup = {x.stem: x for x in beatcloud_tracks}
 

--- a/src/djtools/utils/config.py
+++ b/src/djtools/utils/config.py
@@ -2,11 +2,12 @@
 attributes of this configuration object correspond with the "utils" key of
 config.yaml
 """
+
 import logging
 import os
 from pathlib import Path
 from typing import Dict, List, Optional
-from typing_extensions import Literal
+from typing_extensions import Literal, Union
 
 from pydantic import (
     field_validator,
@@ -38,7 +39,7 @@ class UtilsConfig(BaseConfig):
     PROCESS_RECORDING: bool = False
     RECORDING_FILE: Optional[Path] = None
     RECORDING_PLAYLIST: str = ""
-    SKIP_TRIM_INITIAL_SILENCE: bool = False
+    TRIM_INITIAL_SILENCE: Union[int, Literal["auto", "smart"]] = 0
     URL_DOWNLOAD: str = ""
 
     def __init__(self, *args, **kwargs):

--- a/src/djtools/utils/helpers.py
+++ b/src/djtools/utils/helpers.py
@@ -107,14 +107,17 @@ def find_matches(
     return matches
 
 
-def get_beatcloud_tracks() -> List[str]:
+def get_beatcloud_tracks(bucket_url) -> List[str]:
     """Lists all the music files in S3 and parses out the track titles and
         artist names.
+
+    Args:
+        bucket_url: URL to an AWS S3 API compliant bucket.
 
     Returns:
         Beatcloud track titles and artist names.
     """
-    cmd = ["aws", "s3", "ls", "--recursive", "s3://dj.beatcloud.com/dj/music/"]
+    cmd = ["aws", "s3", "ls", "--recursive", f"{bucket_url}/dj/music/"]
     output = check_output(cmd).decode("utf-8").split("\n")
     tracks = [Path(track) for track in output if track]
     logger.info(f"Got {len(tracks)} tracks from the beatcloud")

--- a/src/djtools/utils/normalize_audio.py
+++ b/src/djtools/utils/normalize_audio.py
@@ -1,5 +1,6 @@
 """This module is used to normalize audio files in one or more directories.
 """
+
 import logging
 
 from pydub import AudioSegment, effects, utils

--- a/src/djtools/utils/process_recording.py
+++ b/src/djtools/utils/process_recording.py
@@ -54,18 +54,15 @@ def process(config: BaseConfig):
     playlist_duration = 0
     for track in tracks[config.RECORDING_PLAYLIST]:
         # Parse release date field based on the date precision
-        if track["track"]["album"]["release_date_precision"] == "year":
-            date = datetime.strptime(
-                track["track"]["album"]["release_date"], "%Y"
-            )
-        elif track["track"]["album"]["release_date_precision"] == "month":
-            date = datetime.strptime(
-                track["track"]["album"]["release_date"], "%Y-%m"
-            )
-        elif track["track"]["album"]["release_date_precision"] == "day":
-            date = datetime.strptime(
-                track["track"]["album"]["release_date"], "%Y-%m-%d"
-            )
+        date_year = ""
+        release_date = track["track"]["album"]["release_date"]
+        release_precision = track["track"]["album"]["release_date_precision"]
+        if release_precision == "year":
+            date_year = datetime.strptime(release_date, "%Y").year
+        elif release_precision == "month":
+            date_year = datetime.strptime(release_date, "%Y-%m").year
+        elif release_precision == "day":
+            date_year = datetime.strptime(release_date, "%Y-%m-%d").year
 
         # TODO(a-rich): Why won't Rekordbox load "label" and "year" tags?!
         data = {
@@ -78,7 +75,7 @@ def process(config: BaseConfig):
             "duration": track["track"]["duration_ms"] + 500,
             "label": track["track"]["album"].get("label", ""),
             "title": track["track"]["name"],
-            "year": str(date.year),
+            "year": date_year,
         }
         track_data.append(data)
         playlist_duration += data["duration"]

--- a/src/djtools/utils/process_recording.py
+++ b/src/djtools/utils/process_recording.py
@@ -9,6 +9,7 @@ information from the Spotify API to:
 - normalize the audio so the headroom is AUDIO_HEADROOM decibels
 - export the files with the configured AUDIO_BITRATE and AUDIO_FORMAT
 """
+
 from concurrent.futures import as_completed, ThreadPoolExecutor
 from datetime import datetime
 import logging
@@ -85,9 +86,11 @@ def process(config: BaseConfig):
     # Load the audio and trim the initial silence.
     logger.info("Loading audio...")
     audio = AudioSegment.from_file(config.RECORDING_FILE)
-    if not config.SKIP_TRIM_INITIAL_SILENCE:
+    if config.TRIM_INITIAL_SILENCE:
         audio = trim_initial_silence(
-            audio, [track["duration"] for track in track_data]
+            audio,
+            [track["duration"] for track in track_data],
+            config.TRIM_INITIAL_SILENCE,
         )
 
     # Check that the audio is at least as long as the playlist duration.

--- a/src/djtools/utils/url_download.py
+++ b/src/djtools/utils/url_download.py
@@ -3,6 +3,7 @@ Soundcloud playlist can be made and the URL of that playlist can be provided to
 download all those tracks and rename them to cleanup the digits appended to the
 files by the youtube-dl package.
 """
+
 import logging
 from pathlib import Path
 import re

--- a/src/djtools/version.py
+++ b/src/djtools/version.py
@@ -1,4 +1,5 @@
 """This module is the single source for this package's version."""
+
 import importlib.metadata
 import re
 

--- a/tests/collection/test_base_collection.py
+++ b/tests/collection/test_base_collection.py
@@ -1,4 +1,5 @@
 """Testing for the collection module."""
+
 import pytest
 
 from djtools.collection.base_collection import Collection

--- a/tests/collection/test_base_playlist.py
+++ b/tests/collection/test_base_playlist.py
@@ -1,4 +1,5 @@
 """Testing for the playlists module."""
+
 import pytest
 
 from djtools.collection.base_playlist import Playlist

--- a/tests/collection/test_base_track.py
+++ b/tests/collection/test_base_track.py
@@ -1,4 +1,5 @@
 """Testing for the tracks module."""
+
 import pytest
 
 from djtools.collection.base_track import Track

--- a/tests/collection/test_config.py
+++ b/tests/collection/test_config.py
@@ -1,4 +1,5 @@
 """Testing for the config module."""
+
 from unittest import mock
 
 import pytest

--- a/tests/collection/test_copy_playlists.py
+++ b/tests/collection/test_copy_playlists.py
@@ -1,4 +1,5 @@
 """Testing for the copy_playlists module."""
+
 from pathlib import Path
 
 import pytest

--- a/tests/collection/test_helpers.py
+++ b/tests/collection/test_helpers.py
@@ -1,4 +1,5 @@
 """Testing for the helpers module."""
+
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path

--- a/tests/collection/test_playlist_builder.py
+++ b/tests/collection/test_playlist_builder.py
@@ -1,4 +1,5 @@
 """Testing for the playlist_builder module."""
+
 from unittest import mock
 
 import pytest

--- a/tests/collection/test_playlist_filters.py
+++ b/tests/collection/test_playlist_filters.py
@@ -1,4 +1,5 @@
 """Testing for the playlist_filters module."""
+
 from unittest import mock
 
 import pytest

--- a/tests/collection/test_rekordbox_collection.py
+++ b/tests/collection/test_rekordbox_collection.py
@@ -1,4 +1,5 @@
 """Testing for the collection module."""
+
 import bs4
 
 from djtools.collection.rekordbox_collection import (

--- a/tests/collection/test_rekordbox_playlist.py
+++ b/tests/collection/test_rekordbox_playlist.py
@@ -1,4 +1,5 @@
 """Testing for the playlists module."""
+
 import pytest
 
 from djtools.collection.rekordbox_playlist import RekordboxPlaylist

--- a/tests/collection/test_rekordbox_track.py
+++ b/tests/collection/test_rekordbox_track.py
@@ -1,4 +1,5 @@
 """Testing for the tracks module."""
+
 from datetime import datetime
 import os
 from pathlib import Path

--- a/tests/collection/test_shuffle_playlists.py
+++ b/tests/collection/test_shuffle_playlists.py
@@ -1,4 +1,5 @@
 """Testing for the shuffle_playlists module."""
+
 import pytest
 
 from djtools.collection.base_playlist import Playlist

--- a/tests/configs/test_cli_args.py
+++ b/tests/configs/test_cli_args.py
@@ -1,4 +1,5 @@
 """Testing for the cli_args module."""
+
 from pathlib import Path
 from typing import List
 
@@ -9,6 +10,7 @@ from djtools.configs.cli_args import (
     get_arg_parser,
     NonEmptyListElementAction,
     _parse_json,
+    _parse_trim_initial_silence,
 )
 
 
@@ -77,3 +79,34 @@ def test_parse_json_invalid():
     json_string = '{"name": {"stuff"}}'
     with pytest.raises(ValueError):
         _parse_json(json_string)
+
+
+def test_parse_trim_initial_silence_int():
+    """Test for the _parse_trim_initial_silence function."""
+    arg = "1"
+    assert isinstance(arg, str)
+    result = _parse_trim_initial_silence(arg)
+    assert isinstance(result, int)
+    assert result == 1
+
+
+def test_parse_trim_initial_silence_str():
+    """Test for the _parse_trim_initial_silence function."""
+    arg = "auto"
+    assert isinstance(arg, str)
+    result = _parse_trim_initial_silence(arg)
+    assert isinstance(result, str)
+    assert result == "auto"
+
+
+def test_parse_trim_initial_silence_invalid_str():
+    """Test for the _parse_trim_initial_silence function."""
+    arg = "stuff"
+    with pytest.raises(
+        ValueError,
+        match=(
+            '--trim-initial-silence must be either "auto", "smart", or an '
+            "integer."
+        ),
+    ):
+        _parse_trim_initial_silence(arg)

--- a/tests/configs/test_config.py
+++ b/tests/configs/test_config.py
@@ -1,4 +1,5 @@
 """Testing for the config module."""
+
 from unittest import mock
 
 import pytest

--- a/tests/configs/test_helpers.py
+++ b/tests/configs/test_helpers.py
@@ -1,4 +1,5 @@
 """Testing for the helpers module."""
+
 import inspect
 import logging
 from pathlib import Path

--- a/tests/spotify/test_config.py
+++ b/tests/spotify/test_config.py
@@ -1,4 +1,5 @@
 """Testing for the config module."""
+
 from unittest import mock
 
 import pytest

--- a/tests/spotify/test_helpers.py
+++ b/tests/spotify/test_helpers.py
@@ -1,4 +1,5 @@
 """Testing for the helpers module."""
+
 import asyncio
 from pathlib import Path
 from unittest import mock
@@ -260,17 +261,19 @@ def test_fuzzy_match(mock_spotify_search, mock_spotify, title, match_result):
     ), mock.patch(
         "djtools.spotify.helpers.filter_results",
         return_value=(
-            {
-                "id": "some_id",
-                "name": "Arctic Oscillations",
-                "artists": [
-                    {"name": "Fanu"},
-                ],
-            },
-            100,
-        )
-        if match_result
-        else (None, 0),
+            (
+                {
+                    "id": "some_id",
+                    "name": "Arctic Oscillations",
+                    "artists": [
+                        {"name": "Fanu"},
+                    ],
+                },
+                100,
+            )
+            if match_result
+            else (None, 0)
+        ),
     ) as mock_filter_results:
         ret = _fuzzy_match(mock_spotify, title, threshold)
     if not all(x for x in title):

--- a/tests/spotify/test_playlist_builder.py
+++ b/tests/spotify/test_playlist_builder.py
@@ -1,4 +1,5 @@
 """Testing for the playlist_builder module."""
+
 from pathlib import Path
 from unittest import mock
 

--- a/tests/sync/test_config.py
+++ b/tests/sync/test_config.py
@@ -16,6 +16,7 @@ def test_syncconfig_download_or_upload_without_usb_path(download, upload):
     """Test for the SyncConfig class."""
     cfg = {
         "AWS_PROFILE": "myprofile",
+        "BUCKET_URL": "s3://some-bucket.com",
         "DOWNLOAD_MUSIC": download,
         "UPLOAD_MUSIC": upload,
         "USB_PATH": None,
@@ -36,6 +37,7 @@ def test_syncconfig_download_or_upload_with_missing_usb_path(download, upload):
     usb_path = Path("not/real/usb/path")
     cfg = {
         "AWS_PROFILE": "myprofile",
+        "BUCKET_URL": "s3://some-bucket.com",
         "DOWNLOAD_MUSIC": download,
         "UPLOAD_MUSIC": upload,
         "USB_PATH": usb_path,
@@ -52,6 +54,7 @@ def test_syncconfig_download_without_import_user():
     cfg = {
         "DOWNLOAD_COLLECTION": True,
         "AWS_PROFILE": "myprofile",
+        "BUCKET_URL": "s3://some-bucket.com",
         "IMPORT_USER": "",
     }
     with pytest.raises(
@@ -98,6 +101,25 @@ def test_syncconfig_no_aws_profile(aws_operation):
         SyncConfig(**cfg)
 
 
+@pytest.mark.parametrize(
+    "aws_operation",
+    [
+        "DOWNLOAD_COLLECTION",
+        "DOWNLOAD_MUSIC",
+        "UPLOAD_COLLECTION",
+        "UPLOAD_MUSIC",
+    ],
+)
+def test_syncconfig_no_bucket(aws_operation):
+    """Test for the SyncConfig class."""
+    cfg = {"AWS_PROFILE": "default", aws_operation: True}
+    with pytest.raises(
+        RuntimeError,
+        match="Config must include BUCKET_URL for sync operations",
+    ):
+        SyncConfig(**cfg)
+
+
 def test_syncconfig_sets_aws_profile_env_var():
     """Test for the SyncConfig class."""
     cfg = {"AWS_PROFILE": "test-profile"}
@@ -131,6 +153,7 @@ def test_syncconfig_upload_without_discord_url(rekordbox_xml, caplog):
     cfg = {
         "USB_PATH": ".",
         "UPLOAD_MUSIC": True,
+        "BUCKET_URL": "s3://some-bucket.com",
         "DISCORD_URL": "",
         "COLLECTION_PATH": rekordbox_xml,
         "SPOTIFY_CLIENT_ID": "id",

--- a/tests/sync/test_config.py
+++ b/tests/sync/test_config.py
@@ -1,4 +1,5 @@
 """Testing for the config module."""
+
 import os
 from pathlib import Path
 import re

--- a/tests/sync/test_helpers.py
+++ b/tests/sync/test_helpers.py
@@ -1,4 +1,5 @@
 """Testing for the helpers module."""
+
 from datetime import datetime, timedelta
 import os
 from pathlib import Path

--- a/tests/sync/test_sync_operations.py
+++ b/tests/sync/test_sync_operations.py
@@ -1,4 +1,5 @@
 """Testing for the sync_operations module."""
+
 from pathlib import Path
 from unittest import mock
 

--- a/tests/sync/test_sync_operations.py
+++ b/tests/sync/test_sync_operations.py
@@ -13,6 +13,7 @@ from djtools.sync.sync_operations import (
 
 
 # pylint: disable=duplicate-code
+TEST_BUCKET = "s3://some-bucket.com"
 
 
 @pytest.mark.parametrize("playlist_name", ["", "playlist Uploads"])
@@ -28,6 +29,7 @@ from djtools.sync.sync_operations import (
 def test_download_music(playlist_name, config, tmpdir, caplog):
     """Test for the download_music function."""
     caplog.set_level("INFO")
+    config.BUCKET_URL = TEST_BUCKET
     config.USB_PATH = tmpdir
     config.DOWNLOAD_SPOTIFY_PLAYLIST = playlist_name
     write_path = Path(tmpdir) / "DJ Music" / "file.mp3"
@@ -35,7 +37,7 @@ def test_download_music(playlist_name, config, tmpdir, caplog):
         "aws",
         "s3",
         "sync",
-        "s3://dj.beatcloud.com/dj/music/",
+        f"{TEST_BUCKET}/dj/music/",
         write_path.parent.as_posix(),
     ]
     if playlist_name:
@@ -51,7 +53,7 @@ def test_download_music(playlist_name, config, tmpdir, caplog):
         side_effect=lambda *args, **kwargs: dummy_func(),
     ) as mock_run_sync:
         download_music(config)
-        mock_run_sync.assert_called_with(cmd)
+        mock_run_sync.assert_called_with(cmd, TEST_BUCKET)
     assert caplog.records[0].message == "Downloading track collection..."
     assert caplog.records[1].message == f"Found 0 files at {config.USB_PATH}"
     assert caplog.records[2].message == " ".join(cmd)
@@ -97,6 +99,7 @@ def test_download_collection(
     test_user = "test_user"
     other_user = "other_user"
     import_user = test_user if user_is_import_user else other_user
+    config.BUCKET_URL = TEST_BUCKET
     config.USER = test_user
     config.IMPORT_USER = import_user
     config.COLLECTION_PATH = rekordbox_xml
@@ -111,7 +114,7 @@ def test_download_collection(
         "aws",
         "s3",
         "cp",
-        f"s3://dj.beatcloud.com/dj/collections/{import_user}/"
+        f"{TEST_BUCKET}/dj/collections/{import_user}/"
         f"{config.PLATFORM}_collection",
         # NOTE(a-rich): since we could be passing a `rekordbox_xml` formatted
         # as a WindowsPath, the comparison needs to be made with `str(new_xml)`
@@ -144,6 +147,7 @@ def test_upload_music(
 ):
     """Test for the upload_music function."""
     caplog.set_level("INFO")
+    config.BUCKET_URL = TEST_BUCKET
     config.USB_PATH = tmpdir
     config.DISCORD_URL = discord_url
     test_dir = Path(tmpdir) / "DJ Music"
@@ -157,7 +161,7 @@ def test_upload_music(
         "s3",
         "sync",
         test_dir.as_posix(),
-        "s3://dj.beatcloud.com/dj/music/",
+        f"{TEST_BUCKET}/dj/music/",
         "--size-only",
     ]
     assert caplog.records[0].message == "Removed 1 files..."
@@ -165,7 +169,7 @@ def test_upload_music(
     assert caplog.records[2].message == "Uploading track collection..."
     assert caplog.records[3].message == " ".join(cmd)
     assert len(list(test_dir.iterdir())) == 1
-    mock_run_sync.assert_called_with(cmd)
+    mock_run_sync.assert_called_with(cmd, TEST_BUCKET)
     if discord_url:
         mock_webhook.assert_called_with(
             "https://discord.com/api/webhooks/some-id/", content=None
@@ -180,6 +184,7 @@ def test_upload_collection(
     """Test for the upload_collection function."""
     caplog.set_level("INFO")
     user = "user"
+    config.BUCKET_URL = TEST_BUCKET
     config.USER = user
     config.COLLECTION_PATH = rekordbox_xml
     config.PLATFORM = "rekordbox"
@@ -188,7 +193,7 @@ def test_upload_collection(
         "s3",
         "cp",
         config.COLLECTION_PATH.as_posix(),
-        f"s3://dj.beatcloud.com/dj/collections/{user}/{config.PLATFORM}_collection",
+        f"{TEST_BUCKET}/dj/collections/{user}/{config.PLATFORM}_collection",
     ]
     if collection_is_dir:
         cmd.append("--recursive")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 """Testing the main entrypoint for the djtools library."""
+
 from unittest import mock
 
 from djtools import main

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 """This module contains testing utilities."""
+
 from pathlib import Path
 import tempfile
 from typing import IO, List, Optional, Tuple

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,4 +1,5 @@
 """Testing the version module."""
+
 from unittest import mock
 
 import semver

--- a/tests/utils/test_check_tracks.py
+++ b/tests/utils/test_check_tracks.py
@@ -1,4 +1,5 @@
 """Testing for the check_tracks module."""
+
 from pathlib import Path
 from unittest import mock
 

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -1,4 +1,5 @@
 """Testing for the config module."""
+
 import os
 import re
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -84,11 +84,12 @@ def test_find_matches(config):
 @mock.patch("djtools.utils.helpers.check_output")
 def test_get_beatcloud_tracks(mock_os_popen, proc_dump):
     """Test for the get_beatcloud_tracks function."""
+    bucket_url = "s3://some-bucket.com"
     proc_dump = list(map(Path, proc_dump))
     mock_os_popen.return_value = b"\n".join(
         map(lambda x: x.as_posix().encode(), proc_dump)
     )
-    tracks = get_beatcloud_tracks()
+    tracks = get_beatcloud_tracks(bucket_url)
     mock_os_popen.assert_called_once()
     assert len(tracks) == len(proc_dump)
     for track, line in zip(tracks, proc_dump):

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -51,7 +51,7 @@ def test_find_matches(config):
         "track 2 - seen them before",
     ]
     matches = find_matches(
-        spotify_tracks={
+        compare_tracks={
             "playlist_a": expected_matches,
             "playlist_b": [
                 "track 3 - special person",
@@ -68,7 +68,7 @@ def test_find_matches(config):
         match[-1] == config.CHECK_TRACKS_FUZZ_RATIO for match in matches
     )
     assert len(matches) == 2
-    assert [x[1] for x in matches] == expected_matches
+    assert {x[1] for x in matches} == set(expected_matches)
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_normalize_audio.py
+++ b/tests/utils/test_normalize_audio.py
@@ -1,4 +1,5 @@
 """Testing for the process_recording module."""
+
 from pathlib import Path
 from unittest import mock
 

--- a/tests/utils/test_process_spotify_recording.py
+++ b/tests/utils/test_process_spotify_recording.py
@@ -1,4 +1,5 @@
 """Testing for the process_recording module."""
+
 from pathlib import Path
 from unittest import mock
 
@@ -56,15 +57,15 @@ def test_process_handles_missing_or_empty_playlist(config):
 )
 @mock.patch("djtools.utils.process_recording.process_parallel", mock.Mock())
 @mock.patch("djtools.utils.process_recording.trim_initial_silence")
-@pytest.mark.parametrize("skip,expected", [(False, 1), (True, 0)])
+@pytest.mark.parametrize("trim,expected", [(0, 0), (1, 1), ("auto", 1)])
 def test_process_skips_trimming_initial_silence(
-    mock_trim_initial_silence, skip, expected, config, tmpdir
+    mock_trim_initial_silence, trim, expected, config, tmpdir
 ):
     """Test for the process function."""
     config.AUDIO_DESTINATION = Path(tmpdir)
     config.RECORDING_FILE = "file.wav"
     config.RECORDING_PLAYLIST = "playlist"
-    config.SKIP_TRIM_INITIAL_SILENCE = skip
+    config.TRIM_INITIAL_SILENCE = trim
     process(config)
     assert mock_trim_initial_silence.call_count == expected
 

--- a/tests/utils/test_url_download.py
+++ b/tests/utils/test_url_download.py
@@ -1,4 +1,5 @@
 """Testing for the url_download module."""
+
 # pylint: disable=duplicate-code
 from pathlib import Path
 from unittest import mock


### PR DESCRIPTION
2.7.14

Bug fixes:
- Fix tqdm progress bars for parallel tasks

Features:
- Configurable `BUCKET_URL` rather than hard-coding `dj.beatcloud.com`
- Date type string selectors can now be, in addition to ISO format strings, `ymwd` (year, month, week, day) time deltas
- `TRIM_INITIAL_SILENCE` (in milliseconds) allows you to manually trim the beginning of `RECORDING_FILE`

Scripts:
- `update_collection` doesn't require `--master-collection` arg any more
- `get_tags_from_playlist` supports filtering tracks by date (or just getting the most recent group)