### PR TITLE
feat: Jinja templating for collection_playlists.yaml

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -82,6 +82,15 @@ def playlist_config():
 
 
 @pytest.fixture
+def playlist_config_content():
+    """Test playlist config content fixture."""
+    with open(
+        "tests/data/collection_playlists.yaml", mode="r", encoding="utf-8"
+    ) as _file:
+        return _file.read()
+
+
+@pytest.fixture
 def playlist_config_obj(
     playlist_config,
 ):  # pylint: disable=redefined-outer-name

--- a/docs/how_to_guides/collection_playlists.md
+++ b/docs/how_to_guides/collection_playlists.md
@@ -16,7 +16,7 @@ If a user diligently tags their Collection using, say, the `Genre` tag, they the
 * Having a change of heart with respect to the genre that a particular track belongs to means that that track must be removed from some existing playlist(s) and added to some different playlist(s)
 * Searching, for example, "Techno" will show not only tracks that contain the word "techno" in their `Genre` tag but also any track that has *any* mention of the word "techno" associated with it (like a dubstep track whose title is "This track is not techno")
 
-The [collection_playlists][djtools.collection.playlist_builder.collection_playlists] feature solves all of these issues! It allows the wisest of users to configure a YAML file with a specification of arbitrary folders and playlists. The playlists' names match the tags that exist in your Collection.
+The [collection_playlists][djtools.collection.playlist_builder.collection_playlists] feature solves all of these issues! It allows the wisest of users to configure a [YAML](https://en.wikipedia.org/wiki/YAML) file with a specification of arbitrary folders and playlists. The playlists' names match the tags that exist in your Collection.
 
 ## How it's done
 
@@ -25,7 +25,7 @@ The [collection_playlists][djtools.collection.playlist_builder.collection_playli
 1. Import the `PLAYLIST_BUILDER` folder from the generated collection
 
 ## Example
-Let's start by examining the pre-packaged [YAML](https://en.wikipedia.org/wiki/YAML) file [collection_playlists.yaml](https://github.com/a-rich/DJ-Tools/blob/main/tests/data/collection_playlists.yaml):
+Let's start by examining the pre-packaged YAML file [collection_playlists.yaml](https://github.com/a-rich/DJ-Tools/blob/main/tests/data/collection_playlists.yaml):
 ![alt text](../images/Rekordbox_playlists_tags_yaml.png "Collection playlists YAML")
 
 You can ignore the `combiner` part of the YAML for now. Although it's similar to the `tags` section, it's covered in the [Combine Playlists With Boolean Algebra](combiner_playlists.md) how-to guide.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,9 @@ disable = [
     "abstract-class-instantiated",
     "broad-except",
     "import-outside-toplevel",
+    "logging-not-lazy",
     "no-name-in-module",
+    "too-many-positional-arguments"
 ]
 good-names = [
     "USER"

--- a/scripts/collection/update_collection.py
+++ b/scripts/collection/update_collection.py
@@ -1,6 +1,6 @@
 """Update master track Collection with local Collection."""
 
-# pylint: disable=duplicate-code
+# pylint: disable=duplicate-code,invalid-name
 from argparse import ArgumentParser
 from itertools import groupby
 from pathlib import Path

--- a/src/djtools/collection/config.py
+++ b/src/djtools/collection/config.py
@@ -38,6 +38,7 @@ class CollectionConfig(BaseConfig):
     COPY_PLAYLISTS_DESTINATION: Optional[Path] = None
     PLATFORM: Literal["rekordbox"] = "rekordbox"
     SHUFFLE_PLAYLISTS: List[str] = []
+    playlist_config: Optional[PlaylistConfig] = None
 
     def __init__(self, *args, **kwargs):
         """Constructor.
@@ -69,26 +70,26 @@ class CollectionConfig(BaseConfig):
             env = Environment(
                 loader=FileSystemLoader(config_path / "playlist_templates")
             )
-            playlists_template = None
-            playlists_template_path = "collection_playlists.j2"
+            playlist_template = None
+            playlist_template_name = "collection_playlists.j2"
             playlist_config_path = config_path / "collection_playlists.yaml"
 
             try:
-                playlist_template = env.get_template(playlists_template_path)
+                playlist_template = env.get_template(playlist_template_name)
             except TemplateNotFound:
                 pass
 
-            if playlists_template:
+            if playlist_template:
                 try:
                     playlist_config = playlist_template.render()
                 except Exception as exc:
                     raise RuntimeError(
-                        f"Failed to render {playlists_template_path}: {exc}"
+                        f"Failed to render {playlist_template_name}: {exc}"
                     )
 
                 if playlist_config_path.exists():
                     logger.warning(
-                        f"Both {playlists_template_path} and "
+                        f"Both {playlist_template_name} and "
                         f"{playlist_config_path.name} exist. Overwriting "
                         f"{playlist_config_path.name} with the rendered "
                         "template"

--- a/src/djtools/collection/config.py
+++ b/src/djtools/collection/config.py
@@ -4,13 +4,15 @@ key of config.yaml
 """
 
 from __future__ import annotations
+
 import logging
 from pathlib import Path
 from typing import List, Optional, Union
 from typing_extensions import Literal
 
-from pydantic import BaseModel, ValidationError
 import yaml
+from jinja2 import Environment, FileSystemLoader, TemplateNotFound
+from pydantic import BaseModel, ValidationError
 
 from djtools.configs.config import BaseConfig
 
@@ -41,6 +43,10 @@ class CollectionConfig(BaseConfig):
         """Constructor.
 
         Raises:
+            RuntimeError: Using the collection package requires a valid
+                COLLECTION_PATH.
+            RuntimeError: Failed to render collection_playlist.yaml from
+                template.
             RuntimeError: COLLECTION_PATH must be a valid collection path.
             RuntimeError: collection_playlists.yaml must be a valid YAML file.
         """
@@ -59,21 +65,51 @@ class CollectionConfig(BaseConfig):
             )
 
         if self.COLLECTION_PLAYLISTS:
-            playlist_config_path = (
-                Path(__file__).parent.parent
-                / "configs"
-                / "collection_playlists.yaml"
+            config_path = Path(__file__).parent.parent / "configs"
+            env = Environment(
+                loader=FileSystemLoader(config_path / "playlist_templates")
             )
+            playlists_template = None
+            playlists_template_path = "collection_playlists.j2"
+            playlist_config_path = config_path / "collection_playlists.yaml"
+
+            try:
+                playlist_template = env.get_template(playlists_template_path)
+            except TemplateNotFound:
+                pass
+
+            if playlists_template:
+                try:
+                    playlist_config = playlist_template.render()
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"Failed to render {playlists_template_path}: {exc}"
+                    )
+
+                if playlist_config_path.exists():
+                    logger.warning(
+                        f"Both {playlists_template_path} and "
+                        f"{playlist_config_path.name} exist. Overwriting "
+                        f"{playlist_config_path.name} with the rendered "
+                        "template"
+                    )
+
+                with open(
+                    playlist_config_path, mode="w", encoding="utf-8"
+                ) as _file:
+                    _file.write(playlist_config)
+
             if not playlist_config_path.exists():
                 raise RuntimeError(
                     "collection_playlists.yaml must exist to use the "
                     "COLLECTION_PLAYLISTS feature"
                 )
+
             try:
                 with open(
                     playlist_config_path, mode="r", encoding="utf-8"
                 ) as _file:
-                    PlaylistConfig(
+                    self.playlist_config = PlaylistConfig(
                         **yaml.load(_file, Loader=yaml.FullLoader) or {}
                     )
             except ValidationError as exc:

--- a/src/djtools/collection/config.py
+++ b/src/djtools/collection/config.py
@@ -85,7 +85,7 @@ class CollectionConfig(BaseConfig):
                 except Exception as exc:
                     raise RuntimeError(
                         f"Failed to render {playlist_template_name}: {exc}"
-                    )
+                    ) from exc
 
                 if playlist_config_path.exists():
                     logger.warning(

--- a/src/djtools/collection/helpers.py
+++ b/src/djtools/collection/helpers.py
@@ -456,6 +456,8 @@ def add_selectors_to_tags(
 
         for playlist_object in [collection, *auto_playlists]:
             for playlist in playlist_object.get_playlists(playlist_name):
+                if playlist.is_folder():
+                    continue
                 tags_tracks[playlist_key].update(playlist.get_tracks())
 
 

--- a/src/djtools/collection/playlist_builder.py
+++ b/src/djtools/collection/playlist_builder.py
@@ -4,8 +4,6 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-import yaml
-
 from djtools.collection.config import PlaylistConfig, PlaylistConfigContent
 from djtools.collection.helpers import (
     add_selectors_to_tags,

--- a/src/djtools/collection/playlist_builder.py
+++ b/src/djtools/collection/playlist_builder.py
@@ -78,7 +78,7 @@ def collection_playlists(config: BaseConfig, path: Optional[Path] = None):
         config: Configuration object.
         path: Path to write the new collection to.
     """
-    config.playlist_config = PlaylistConfig(**config.playlist_config)
+    config.playlist_config = PlaylistConfig(**config.playlist_config or {})
 
     # Check if the playlist config is populated before continuing.
     if not (config.playlist_config.tags or config.playlist_config.combiner):

--- a/src/djtools/collection/playlist_builder.py
+++ b/src/djtools/collection/playlist_builder.py
@@ -78,18 +78,10 @@ def collection_playlists(config: BaseConfig, path: Optional[Path] = None):
         config: Configuration object.
         path: Path to write the new collection to.
     """
-    # Load the playlist config.
-    with open(
-        Path(__file__).parent.parent / "configs" / "collection_playlists.yaml",
-        mode="r",
-        encoding="utf-8",
-    ) as _file:
-        playlist_config = PlaylistConfig(
-            **yaml.load(_file, Loader=yaml.FullLoader) or {}
-        )
+    config.playlist_config = PlaylistConfig(**config.playlist_config)
 
     # Check if the playlist config is populated before continuing.
-    if not (playlist_config.tags or playlist_config.combiner):
+    if not (config.playlist_config.tags or config.playlist_config.combiner):
         logger.warning(
             "Not building playlists because the playlist config is empty."
         )
@@ -119,12 +111,12 @@ def collection_playlists(config: BaseConfig, path: Optional[Path] = None):
     ]
 
     # Create playlists for the "tags" portion of the playlist config.
-    if playlist_config.tags:
+    if config.playlist_config.tags:
         # A set of tags seen is maintained while creating the tags playlists so
         # that they are ignored when creating the "Other" playlists.
         seen_tags = set()
         tag_playlists = build_tag_playlists(
-            playlist_config.tags, tags_tracks, playlist_class, seen_tags
+            config.playlist_config.tags, tags_tracks, playlist_class, seen_tags
         )
 
         # The tag playlists must have their "parent" attribute set so that
@@ -174,16 +166,19 @@ def collection_playlists(config: BaseConfig, path: Optional[Path] = None):
             )
 
     # Create playlists for the "combiner" portion of the playlist config.
-    if playlist_config.combiner:
+    if config.playlist_config.combiner:
         # Parse selectors from the combiner playlist names and update the
         # tags_tracks mapping.
         add_selectors_to_tags(
-            playlist_config.combiner, tags_tracks, collection, auto_playlists
+            config.playlist_config.combiner,
+            tags_tracks,
+            collection,
+            auto_playlists,
         )
 
         # Evaluate the boolean logic of the combiner playlists.
         combiner_playlists = build_combiner_playlists(
-            playlist_config.combiner, tags_tracks, playlist_class
+            config.playlist_config.combiner, tags_tracks, playlist_class
         )
 
         # The tag playlists must have their "parent" attribute set so that

--- a/tests/collection/test_config.py
+++ b/tests/collection/test_config.py
@@ -75,6 +75,15 @@ def test_collectionconfig_invalid_collection_playlists_config(rekordbox_xml):
         CollectionConfig(**cfg)
 
 
+@mock.patch(
+    "djtools.collection.config.Path.exists",
+    lambda path: mock_exists(
+        [
+            ("collection_playlists.yaml", True),
+        ],
+        path,
+    ),
+)
 def test_collectionconfig_without_template(
     rekordbox_xml, playlist_config_content, playlist_config_obj
 ):
@@ -91,6 +100,21 @@ def test_collectionconfig_without_template(
     assert config.playlist_config == playlist_config_obj
 
 
+@mock.patch(
+    "djtools.collection.config.Path.exists",
+    lambda path: mock_exists(
+        [
+            ("collection_playlists.yaml", True),
+        ],
+        path,
+    ),
+)
+@mock.patch(
+    "builtins.open",
+    MockOpen(
+        files=["collection_playlists.yaml"],
+    ).open,
+)
 @mock.patch("djtools.collection.config.Environment.get_template")
 def test_collectionconfig_with_template(mock_get_template, rekordbox_xml):
     """Test for the CollectionConfig class."""

--- a/tests/collection/test_helpers.py
+++ b/tests/collection/test_helpers.py
@@ -501,6 +501,25 @@ def test_add_selectors_to_tags(
         assert set(tags_tracks[tag]) == tracks
 
 
+@pytest.mark.parametrize(
+    "playlist_selector,in_tags_tracks",
+    [
+        ("{playlist:Genres}", False),
+        ("{playlist:Hip Hop}", True),
+    ],
+)
+def test_add_selectors_to_tags_skips_playlists_that_are_folders(
+    playlist_selector, in_tags_tracks, rekordbox_collection
+):
+    """Test for the add_selectors_to_tags function."""
+    playlist_content = f"{playlist_selector} & [0]"
+    tags_tracks = defaultdict(dict)
+    add_selectors_to_tags(
+        playlist_content, tags_tracks, rekordbox_collection, []
+    )
+    assert (playlist_selector in tags_tracks) == in_tags_tracks
+
+
 def test_parse_numerical_selectors():
     """Test for the parse_numerical_selectors function."""
     matches = ["1", "2-4", "140", "141-143", "2021", "2021-2023"]
@@ -620,7 +639,7 @@ def test_parse_string_selectors_warns_bad(matches, expected, caplog):
 @pytest.mark.parametrize("time_str", ["1y", "6m", "3m2w", "7d"])
 def test_parse_timedelta(time_str):
     """Test for the parse_timedelta function."""
-    with mock.patch("datetime.datetime") as mock_datetime:
+    with mock.patch("djtools.collection.helpers.datetime") as mock_datetime:
         mock_datetime.now.return_value = datetime(2024, 6, 22, 0, 0)
         relative_time = parse_timedelta(time_str)
         assert relative_time < mock_datetime.now.return_value

--- a/tests/collection/test_playlist_builder.py
+++ b/tests/collection/test_playlist_builder.py
@@ -37,14 +37,9 @@ def test_collection_playlists_makes_unused_tags_playlists(
 
     del playlist_config["combiner"]
     playlist_config["tags"]["playlists"] = [some_tag]
+    config.playlist_config = playlist_config
 
-    with mock.patch(
-        "builtins.open",
-        MockOpen(
-            files=["collection_playlists.yaml"], content=f"{playlist_config}"
-        ).open,
-    ):
-        collection_playlists(config, path=new_path)
+    collection_playlists(config, path=new_path)
 
     # Since our "tags" config only specifies one tag, and there is more than
     # one tag in the collection, there must be a playlist called "Unused Tags".
@@ -107,16 +102,10 @@ def test_collection_playlists_prints_playlist_tag_statistics(
     """Test for the collection_playlists function."""
     config.COLLECTION_PATH = rekordbox_xml
     config.VERBOSITY = 1
+    config.playlist_config = playlist_config
 
-    with mock.patch(
-        "builtins.open",
-        MockOpen(
-            files=["collection_playlists.yaml"], content=f"{playlist_config}"
-        ).open,
-    ):
-        collection_playlists(
-            config, path=rekordbox_xml.parent / "test_collection"
-        )
+    collection_playlists(config, path=rekordbox_xml.parent / "test_collection")
+
     assert mock_print_playlists_tag_statistics.call_count == 1
 
 
@@ -140,15 +129,10 @@ def test_collection_playlists_handles_error_parsing_expression(
     playlist_config["combiner"]["playlists"] = [
         {"name": "test", "playlists": [invalid_expression]}
     ]
-    with mock.patch(
-        "builtins.open",
-        MockOpen(
-            files=["collection_playlists.yaml"], content=f"{playlist_config}"
-        ).open,
-    ):
-        collection_playlists(
-            config, path=rekordbox_xml.parent / "test_collection"
-        )
+    config.playlist_config = playlist_config
+
+    collection_playlists(config, path=rekordbox_xml.parent / "test_collection")
+
     assert caplog.records[0].message.startswith(
         "Error parsing expression: this & & will be invalid"
     )
@@ -175,15 +159,11 @@ def test_collection_playlists_removes_existing_playlist(
     new_path = rekordbox_xml.parent / "test_collection"
     collection.serialize(path=new_path)
     config.COLLECTION_PATH = new_path
+    config.playlist_config = playlist_config
 
     # Run the playlist_builder on this collection to test removing the existing
     # playlist_builder playlist.
     with mock.patch(
-        "builtins.open",
-        MockOpen(
-            files=["collection_playlists.yaml"], content=f"{playlist_config}"
-        ).open,
-    ), mock.patch(
         "djtools.collection.rekordbox_collection.RekordboxCollection.add_playlist"
     ):
         collection_playlists(config, path=new_path)
@@ -192,16 +172,13 @@ def test_collection_playlists_removes_existing_playlist(
     assert not collection.get_playlists(PLAYLIST_NAME)
 
 
-@mock.patch(
-    "builtins.open",
-    MockOpen(files=["collection_playlists.yaml"], content="{}").open,
-)
 def test_collection_playlists_with_empty_playlistconfig_returns_early(
     config, rekordbox_xml, caplog
 ):
     """Test for the collection_playlists function."""
     caplog.set_level("WARNING")
     config.COLLECTION_PATH = rekordbox_xml
+    config.playlist_config = {}
     collection_playlists(config, path=rekordbox_xml.parent / "test_collection")
     assert caplog.records[0].message == (
         "Not building playlists because the playlist config is empty."

--- a/tests/collection/test_playlist_builder.py
+++ b/tests/collection/test_playlist_builder.py
@@ -11,8 +11,6 @@ from djtools.collection.playlist_builder import (
 from djtools.collection.rekordbox_collection import RekordboxCollection
 from djtools.collection.rekordbox_playlist import RekordboxPlaylist
 
-from ..test_utils import MockOpen
-
 
 @pytest.mark.parametrize("remainder_type", ["folder", "playlist"])
 def test_collection_playlists_makes_unused_tags_playlists(

--- a/tests/configs/test_cli_args.py
+++ b/tests/configs/test_cli_args.py
@@ -51,7 +51,11 @@ def test_get_arg_parser_arg_for_every_field(config):
 
     # Test that every config option has a corresponding CLI arg.
     config_only = config_set.difference(args_set)
-    assert config_only == set(), (
+
+    # NOTE: playlist_config is the only BaseConfig attribute that doesn't have
+    # a corresponding CLI arg. This is because the CollectionConfig preloads
+    # the user's collection playlists.
+    assert config_only == {"playlist_config"}, (
         "Expected a CLI arg for every config option but these were missing:"
         f"\n{config_only}"
     )


### PR DESCRIPTION
- When building the `CollectionConfig`, look for a `configs/playlist_templates/collection_playlists.j2`
- Render that template and overwrite `configs/collection_playlists.yaml`
- Set the loaded `PlaylistConfig` object on the `CollectionConfig` (instead of validating in `CollectionConfig` and then loading in the `collection_playlists` function.
- Includes a bug fix for when trying to update `tags_tracks` with `playlist.get_tracks()` when that playlist is actually a folder