### PR TITLE
Feat/supress sub config repr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,11 @@ line-length = 79
 source = ["src"]
 omit = ["src/djtools/__main__.py"]
 
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover"
+]
+
 [tool.pylint.DESIGN]
 disable = [
     "abstract-class-instantiated",

--- a/scripts/collection/cluster_tracks.py
+++ b/scripts/collection/cluster_tracks.py
@@ -12,8 +12,8 @@ from tqdm import tqdm
 
 from djtools.collection.base_collection import Collection
 from djtools.collection.base_playlist import Playlist
-from djtools.collection.helpers import PLATFORM_REGISTRY
 from djtools.collection.base_track import Track
+from djtools.collection.platform_registry import PLATFORM_REGISTRY
 from djtools.configs import build_config
 
 

--- a/scripts/collection/get_tags_from_spotify.py
+++ b/scripts/collection/get_tags_from_spotify.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 
 from djtools.configs.helpers import build_config
 from djtools.collection.base_track import Track
-from djtools.collection.helpers import PLATFORM_REGISTRY
+from djtools.collection.platform_registry import PLATFORM_REGISTRY
 from djtools.spotify.helpers import filter_results, get_spotify_client
 
 
@@ -140,12 +140,12 @@ if __name__ == "__main__":
 
     # Build config, instantiate collection, and get tracks.
     config = build_config(args.config)
-    collection = PLATFORM_REGISTRY[config.platform]["collection"](
-        path=args.collection or config.collection_path
+    collection = PLATFORM_REGISTRY[config.collection.platform]["collection"](
+        path=args.collection or config.collection.collection_path
     )
     tracks = filter_tracks(collection.get_tracks(), args.date_filter)
     spotify = get_spotify_client(config)
-    playlist_class = PLATFORM_REGISTRY[config.platform]["playlist"]
+    playlist_class = PLATFORM_REGISTRY[config.collection.platform]["playlist"]
 
     # Add tags from Spotify.
     if args.mode == "bulk":
@@ -233,7 +233,9 @@ if __name__ == "__main__":
                         "Response must contain either 'n' or 'y' -- try again!"
                     )
 
-        playlist_class = PLATFORM_REGISTRY[config.platform]["playlist"]
+        playlist_class = PLATFORM_REGISTRY[config.collection.platform][
+            "playlist"
+        ]
         for name, set_tracks in [
             ("No matches", no_matches),
             ("Same", same_tracks),
@@ -244,4 +246,4 @@ if __name__ == "__main__":
             )
             collection.add_playlist(playlist)
 
-    collection.serialize(path=args.output or config.collection_path)
+    collection.serialize(path=args.output or config.collection.collection_path)

--- a/scripts/collection/remove_files_not_in_collection.py
+++ b/scripts/collection/remove_files_not_in_collection.py
@@ -5,7 +5,7 @@ from argparse import ArgumentParser, Namespace
 from pathlib import Path
 
 from djtools.configs import build_config
-from djtools.collection.helpers import PLATFORM_REGISTRY
+from djtools.collection.platform_registry import PLATFORM_REGISTRY
 
 
 # pylint: disable=missing-function-docstring

--- a/scripts/collection/remove_tags_from_comments.py
+++ b/scripts/collection/remove_tags_from_comments.py
@@ -17,7 +17,7 @@ import sys
 from tqdm import tqdm
 
 from djtools.configs.helpers import build_config
-from djtools.collection.helpers import PLATFORM_REGISTRY
+from djtools.collection.platform_registry import PLATFORM_REGISTRY
 
 
 def remove_tags_thread(track, tag_regex, remove_tags):

--- a/scripts/collection/sort_tags.py
+++ b/scripts/collection/sort_tags.py
@@ -7,7 +7,7 @@ from argparse import ArgumentParser
 import re
 
 from djtools.configs import build_config
-from djtools.collection.helpers import PLATFORM_REGISTRY
+from djtools.collection.platform_registry import PLATFORM_REGISTRY
 
 
 TAG_ORDERINGS = (

--- a/scripts/collection/update_collection.py
+++ b/scripts/collection/update_collection.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from subprocess import Popen
 
 from djtools.configs import build_config
-from djtools.collection.helpers import PLATFORM_REGISTRY
+from djtools.collection.platform_registry import PLATFORM_REGISTRY
 
 
 if __name__ == "__main__":
@@ -58,10 +58,10 @@ if __name__ == "__main__":
     if args.collection:
         collection_path = Path(args.collection)
     else:
-        collection_path = config.collection_path
+        collection_path = config.collection.collection_path
 
     # Load collection and get a dict of tracks keyed by location.
-    collection = PLATFORM_REGISTRY[config.platform]["collection"](
+    collection = PLATFORM_REGISTRY[config.collection.platform]["collection"](
         path=collection_path
     )
     tracks = {
@@ -76,8 +76,8 @@ if __name__ == "__main__":
         remote_master_collection = args.master_collection
     else:
         remote_master_collection = (
-            f"{config.bucket_url}/dj/collections/"
-            f"{args.master_collection_user}/{config.platform}_collection"
+            f"{config.sync.bucket_url}/dj/collections/"
+            f"{args.master_collection_user}/{config.collection.platform.value}_collection"
         )
 
     # Download the master collection and get a dict of its tracks too.
@@ -87,9 +87,9 @@ if __name__ == "__main__":
         cmd.append("--recursive")
     with Popen(cmd) as proc:
         proc.wait()
-    master_collection = PLATFORM_REGISTRY[config.platform]["collection"](
-        path=master_collection_path
-    )
+    master_collection = PLATFORM_REGISTRY[config.collection.platform][
+        "collection"
+    ](path=master_collection_path)
     master_tracks = master_collection.get_tracks()
     master_tracks = {
         track.get_location().as_posix(): track

--- a/scripts/collection/update_library_playlist.py
+++ b/scripts/collection/update_library_playlist.py
@@ -103,7 +103,7 @@ def filter_tracks(
 def find_track(track: Track, config: BaseConfig, spotify: Spotify):
     title = track._Name
     artist = track.get_artists()
-    threshold = config.spotify_playlist_fuzz_ratio
+    threshold = config.spotify.spotify_playlist_fuzz_ratio
     query = f"track:{title} artist:{artist}"
     try:
         results = spotify.search(q=query, type="track", limit=50)
@@ -129,7 +129,7 @@ def main(config_path: Path, date_filter: datetime, playlist_name: str):
     spotify = get_spotify_client(config)
     playlist_ids = get_playlist_ids()
 
-    collection = RekordboxCollection(config.collection_path)
+    collection = RekordboxCollection(config.collection.collection_path)
     tracks = filter_tracks(collection.get_tracks(), date_filter)
     tracks = sorted(tracks.values(), key=lambda x: x.get_date_added())
 
@@ -152,7 +152,7 @@ def main(config_path: Path, date_filter: datetime, playlist_name: str):
         playlist_ids = populate_playlist(
             playlist_name=playlist_name,
             playlist_ids=playlist_ids,
-            spotify_username=config.spotify_username,
+            spotify_username=config.spotify.spotify_username,
             spotify=spotify,
             tracks=chunk,
             verbosity=config.verbosity,

--- a/scripts/collection/user_vibe_analysis.py
+++ b/scripts/collection/user_vibe_analysis.py
@@ -12,7 +12,7 @@ from matplotlib.ticker import MaxNLocator
 
 from djtools.configs import build_config
 from djtools.collection.base_collection import Collection
-from djtools.collection.helpers import PLATFORM_REGISTRY
+from djtools.collection.platform_registry import PLATFORM_REGISTRY
 
 
 def analyze_collection_vibes(

--- a/src/djtools/__init__.py
+++ b/src/djtools/__init__.py
@@ -72,7 +72,7 @@ def main():
     # Test ci
     logger, log_file = initialize_logger()
     config = build_config()
-    logger.setLevel(config.log_level)
+    logger.setLevel(config.log_level.value)
 
     # Run "collection", "spotify", "sync", and "utils" package operations if
     # any of the flags to do so are present in the config.

--- a/src/djtools/collection/config.py
+++ b/src/djtools/collection/config.py
@@ -4,8 +4,9 @@ key of config.yaml
 """
 
 import logging
+from enum import Enum
 from pathlib import Path
-from typing import List, Literal, Optional, Union
+from typing import List, Optional, Union
 
 import yaml
 from jinja2 import Environment, FileSystemLoader, TemplateNotFound
@@ -17,25 +18,84 @@ from djtools.configs.config_formatter import BaseConfigFormatter
 logger = logging.getLogger(__name__)
 
 
+class PlaylistFilters(Enum):
+    """PlaylistFilters enum."""
+
+    COMPLEX_TRACK_FILTER = "ComplexTrackFilter"
+    HIPHOP_FILTER = "HipHopFilter"
+    MINIMAL_DEEP_TECH_FILTER = "MinimalDeepTechFilter"
+    TRANSITION_TRACK_FILTER = "TransitionTrackFilter"
+
+
+def playlist_filter_representer(dumper, data):
+    # pylint: disable=missing-function-docstring
+    return dumper.represent_scalar("!PlaylistFilters", data.value)
+
+
+def playlist_filter_constructor(loader, node):
+    # pylint: disable=missing-function-docstring
+    return PlaylistFilters(loader.construct_scalar(node))
+
+
+yaml.add_representer(PlaylistFilters, playlist_filter_representer)
+yaml.add_constructor("!PlaylistFilters", playlist_filter_constructor)
+
+
+class PlaylistRemainder(Enum):
+    """PlaylistRemainder enum."""
+
+    FOLDER = "folder"
+    PLAYLIST = "playlist"
+
+
+def playlist_remainder_representer(dumper, data):
+    # pylint: disable=missing-function-docstring
+    return dumper.represent_scalar("!PlaylistRemainder", data.value)
+
+
+def playlist_remainder_constructor(loader, node):
+    # pylint: disable=missing-function-docstring
+    return PlaylistRemainder(loader.construct_scalar(node))
+
+
+yaml.add_representer(PlaylistRemainder, playlist_remainder_representer)
+yaml.add_constructor("!PlaylistRemainder", playlist_remainder_constructor)
+
+
+class RegisteredPlatforms(Enum):
+    """RegisteredPlatforms enum."""
+
+    REKORDBOX = "rekordbox"
+
+
+def registered_platforms_representer(dumper, data):
+    # pylint: disable=missing-function-docstring
+    return dumper.represent_scalar("!RegisteredPlatforms", data.value)
+
+
+def registered_platforms_constructor(loader, node):
+    # pylint: disable=missing-function-docstring
+    return RegisteredPlatforms(loader.construct_scalar(node))
+
+
+yaml.add_representer(RegisteredPlatforms, registered_platforms_representer)
+yaml.add_constructor("!RegisteredPlatforms", registered_platforms_constructor)
+
+
 class CollectionConfig(BaseConfigFormatter):
     """Configuration object for the collection package."""
 
     collection_path: Optional[Path] = None
-    collection_playlist_filters: List[
-        Literal[
-            "HipHopFilter",
-            "MinimalDeepTechFilter",
-            "ComplexTrackFilter",
-            "TransitionTrackFilter",
-        ]
-    ] = []
+    collection_playlist_filters: List[PlaylistFilters] = []
     collection_playlists: bool = False
-    collection_playlists_remainder: Literal["folder", "playlist"] = "folder"
+    collection_playlists_remainder: PlaylistRemainder = (
+        PlaylistRemainder.FOLDER
+    )
     copy_playlists: List[str] = []
     copy_playlists_destination: Optional[Path] = None
     minimum_combiner_playlist_tracks: Optional[PositiveInt] = None
     minimum_tag_playlist_tracks: Optional[PositiveInt] = None
-    platform: Literal["rekordbox"] = "rekordbox"
+    platform: RegisteredPlatforms = RegisteredPlatforms.REKORDBOX
     shuffle_playlists: List[str] = []
     playlist_config: Optional["PlaylistConfig"] = None
 

--- a/src/djtools/collection/config.py
+++ b/src/djtools/collection/config.py
@@ -29,12 +29,14 @@ class PlaylistFilters(Enum):
 
 def playlist_filter_representer(dumper, data):
     # pylint: disable=missing-function-docstring
-    return dumper.represent_scalar("!PlaylistFilters", data.value)
+    return dumper.represent_scalar(  # pragma: no cover
+        "!PlaylistFilters", data.value
+    )
 
 
 def playlist_filter_constructor(loader, node):
     # pylint: disable=missing-function-docstring
-    return PlaylistFilters(loader.construct_scalar(node))
+    return PlaylistFilters(loader.construct_scalar(node))  # pragma: no cover
 
 
 yaml.add_representer(PlaylistFilters, playlist_filter_representer)

--- a/src/djtools/collection/platform_registry.py
+++ b/src/djtools/collection/platform_registry.py
@@ -1,5 +1,6 @@
 """This module contains the platform registry for supported DJ software."""
 
+from djtools.collection.config import RegisteredPlatforms
 from djtools.collection.rekordbox_collection import RekordboxCollection
 from djtools.collection.rekordbox_playlist import RekordboxPlaylist
 from djtools.collection.rekordbox_track import RekordboxTrack
@@ -9,7 +10,7 @@ from djtools.collection.rekordbox_track import RekordboxTrack
 # platform name must be registered with references to their Collection,
 # Playlist, and Track implementations.
 PLATFORM_REGISTRY = {
-    "rekordbox": {
+    RegisteredPlatforms.REKORDBOX: {
         "collection": RekordboxCollection,
         "playlist": RekordboxPlaylist,
         "track": RekordboxTrack,

--- a/src/djtools/collection/playlist_builder.py
+++ b/src/djtools/collection/playlist_builder.py
@@ -6,7 +6,6 @@ from typing import Optional, Type
 
 from djtools.collection import playlist_filters
 from djtools.collection.config import (
-    PlaylistConfig,
     PlaylistConfigContent,
     PlaylistRemainder,
 )
@@ -80,10 +79,6 @@ def collection_playlists(config: BaseConfig, path: Optional[Path] = None):
         config: Configuration object.
         path: Path to write the new collection to.
     """
-    config.collection.playlist_config = PlaylistConfig(
-        **config.collection.playlist_config or {}
-    )
-
     # Check if the playlist config is populated before continuing.
     if not (
         config.collection.playlist_config.tags
@@ -119,7 +114,7 @@ def collection_playlists(config: BaseConfig, path: Optional[Path] = None):
 
     # List of PlaylistFilter implementations to run against built playlists.
     filters = [
-        getattr(playlist_filters, playlist_filter)()
+        getattr(playlist_filters, playlist_filter.value)()
         for playlist_filter in config.collection.collection_playlist_filters
     ]
 

--- a/src/djtools/collection/playlist_builder.py
+++ b/src/djtools/collection/playlist_builder.py
@@ -5,7 +5,11 @@ from pathlib import Path
 from typing import Optional, Type
 
 from djtools.collection import playlist_filters
-from djtools.collection.config import PlaylistConfig, PlaylistConfigContent
+from djtools.collection.config import (
+    PlaylistConfig,
+    PlaylistConfigContent,
+    PlaylistRemainder,
+)
 from djtools.collection.helpers import (
     add_selectors_to_tags,
     aggregate_playlists,
@@ -154,7 +158,10 @@ def collection_playlists(config: BaseConfig, path: Optional[Path] = None):
         # and create either an "Other" folder of playlists or simply an "Other"
         # playlist.
         other_tags = sorted(set(tags_tracks).difference(seen_tags))
-        if config.collection.collection_playlists_remainder == "folder":
+        if (
+            config.collection.collection_playlists_remainder
+            == PlaylistRemainder.FOLDER
+        ):
             auto_playlists.append(
                 build_tag_playlists(
                     PlaylistConfigContent(

--- a/src/djtools/configs/cli_args.py
+++ b/src/djtools/configs/cli_args.py
@@ -5,7 +5,9 @@ the CLI args.
 import json
 from argparse import Action, ArgumentParser, Namespace, RawTextHelpFormatter
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, Union
+from typing import Dict, List, Optional, Union
+
+from djtools.utils.config import TrimInitialSilenceMode
 
 
 def get_arg_parser() -> ArgumentParser:
@@ -568,8 +570,8 @@ def _parse_json(_json: str) -> Dict:
 
 def _parse_trim_initial_silence(
     arg: str,
-) -> Union[int, Literal["auto", "smart"]]:
-    if arg in {"auto", "smart"}:
+) -> Union[int, TrimInitialSilenceMode]:
+    if isinstance(arg, TrimInitialSilenceMode):
         return arg
 
     try:

--- a/src/djtools/configs/config.py
+++ b/src/djtools/configs/config.py
@@ -4,7 +4,7 @@ apply to multiple packages. The attributes of this configuration object
 correspond with the "configs" key of config.yaml."""
 
 import logging
-from typing import Literal
+from enum import Enum
 
 from pydantic import Field, NonNegativeInt
 
@@ -18,13 +18,21 @@ from djtools.utils.config import UtilsConfig
 logger = logging.getLogger(__name__)
 
 
+class LogLevel(Enum):
+    """Log level Enum."""
+
+    debug = "DEBUG"
+    info = "INFO"
+    warning = "WARNING"
+    error = "ERROR"
+    critical = "CRITICAL"
+
+
 class BaseConfig(BaseConfigFormatter):
     """Base configuration object used across the whole library."""
 
     collection: CollectionConfig = Field(default_factory=CollectionConfig)
-    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = (
-        "INFO"
-    )
+    log_level: LogLevel = LogLevel.info
     spotify: SpotifyConfig = Field(default_factory=SpotifyConfig)
     sync: SyncConfig = Field(default_factory=SyncConfig)
     utils: UtilsConfig = Field(default_factory=UtilsConfig)

--- a/src/djtools/configs/config.py
+++ b/src/djtools/configs/config.py
@@ -7,6 +7,7 @@ import logging
 from enum import Enum
 
 from pydantic import Field, NonNegativeInt
+import yaml
 
 from djtools.collection.config import CollectionConfig
 from djtools.configs.config_formatter import BaseConfigFormatter
@@ -21,19 +22,38 @@ logger = logging.getLogger(__name__)
 class LogLevel(Enum):
     """Log level Enum."""
 
-    debug = "DEBUG"
-    info = "INFO"
-    warning = "WARNING"
-    error = "ERROR"
-    critical = "CRITICAL"
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+    CRITICAL = "CRITICAL"
+
+
+def log_level_representer(dumper, data):
+    # pylint: disable=missing-function-docstring
+    return dumper.represent_scalar("!LogLevel", data.value)
+
+
+def log_level_constructor(loader, node):
+    # pylint: disable=missing-function-docstring
+    return LogLevel(loader.construct_scalar(node))
+
+
+yaml.add_representer(LogLevel, log_level_representer)
+yaml.add_constructor("!LogLevel", log_level_constructor)
 
 
 class BaseConfig(BaseConfigFormatter):
     """Base configuration object used across the whole library."""
 
     collection: CollectionConfig = Field(default_factory=CollectionConfig)
-    log_level: LogLevel = LogLevel.info
+    log_level: LogLevel = LogLevel.INFO
     spotify: SpotifyConfig = Field(default_factory=SpotifyConfig)
     sync: SyncConfig = Field(default_factory=SyncConfig)
     utils: UtilsConfig = Field(default_factory=UtilsConfig)
     verbosity: NonNegativeInt = 0
+
+    class Config:
+        """Class necessary to support deserializing Enums."""
+
+        extra = "allow"

--- a/src/djtools/configs/config_formatter.py
+++ b/src/djtools/configs/config_formatter.py
@@ -25,8 +25,10 @@ class BaseConfigFormatter(BaseModel, extra="forbid"):
         spaces = "\t" * indent_level
 
         if isinstance(value, BaseConfigFormatter):
+            # pylint: disable=unnecessary-dunder-call
             return value.__repr__(indent=indent_level + 1).lstrip("\t")
-        elif (
+
+        if (
             isinstance(value, list)
             and len(value)
             and all(isinstance(v, dict) for v in value)
@@ -37,7 +39,8 @@ class BaseConfigFormatter(BaseModel, extra="forbid"):
                 + f"\n{spaces}]"
             )
             return formatted_list
-        elif isinstance(value, list) and len(value):
+
+        if isinstance(value, list) and len(value):
             formatted_list = (
                 "[\n"
                 + ",\n".join(spaces + "\t" + repr(v) for v in value)

--- a/src/djtools/configs/config_formatter.py
+++ b/src/djtools/configs/config_formatter.py
@@ -3,6 +3,7 @@ BaseModel that defines a __repr__ method to be used by all the config objects
 used in this library."""
 
 import logging
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -10,28 +11,51 @@ from pydantic import BaseModel
 logger = logging.getLogger(__name__)
 
 
-class BaseConfigFormatter(BaseModel, extra="allow"):
+class BaseConfigFormatter(BaseModel, extra="forbid"):
     """Pydantic BaseModel with a __repr__ method for pretty printing."""
 
     def __init__(self, *args, **kwargs):
         """Constructor."""
         super().__init__(*args, **kwargs)
-        logger.info(repr(self))
 
-    def __repr__(self):
-        ret = f"{self.__class__.__name__}("
+        if self.__class__.__name__ == "BaseConfig":
+            logger.info(repr(self))
 
-        for name, value in self.model_dump().items():
-            if (
-                isinstance(value, list)
-                and len(value) > 1
-                and isinstance(value[0], (dict, list, set))
-            ):
-                ret += f"\n\t{name}=[\n\t\t"
-                ret += "\n\t\t".join(str(v) for v in value)
-                ret += "\n\t]"
-                continue
-            ret += f"\n\t{name}={str(value)}"
-        ret += "\n)"
+    def _format_value(self, value: Any, indent_level: int) -> str:
+        spaces = "\t" * indent_level
+
+        if isinstance(value, BaseConfigFormatter):
+            return value.__repr__(indent=indent_level + 1).lstrip("\t")
+        elif (
+            isinstance(value, list)
+            and len(value)
+            and all(isinstance(v, dict) for v in value)
+        ):
+            formatted_list = (
+                "[\n"
+                + ",\n".join(spaces + "\t" + str(v) for v in value)
+                + f"\n{spaces}]"
+            )
+            return formatted_list
+        elif isinstance(value, list) and len(value):
+            formatted_list = (
+                "[\n"
+                + ",\n".join(spaces + "\t" + repr(v) for v in value)
+                + f"\n{spaces}]"
+            )
+            return formatted_list
+
+        return repr(value)
+
+    def __repr__(self, indent: int = 1) -> str:
+        spaces = "\t" * (indent - 1)
+        inner_spaces = "\t" * indent
+        ret = f"{spaces}{self.__class__.__name__}("
+
+        for name in self.__fields__:
+            formatted_value = self._format_value(getattr(self, name), indent)
+            ret += f"\n{inner_spaces}{name}={formatted_value}"
+
+        ret += f"\n{spaces})"
 
         return ret

--- a/src/djtools/spotify/helpers.py
+++ b/src/djtools/spotify/helpers.py
@@ -24,6 +24,8 @@ from fuzzywuzzy import fuzz
 from spotipy.oauth2 import SpotifyOAuth
 from tqdm import tqdm
 
+from djtools.spotify.config import SubredditType
+
 
 logger = logging.getLogger(__name__)
 BaseConfig = Type["BaseConfig"]
@@ -166,9 +168,9 @@ async def get_subreddit_posts(
             dictionary.
     """
     sub = await reddit.subreddit(subreddit.name)
-    func = getattr(sub, subreddit.type)
+    func = getattr(sub, subreddit.type.value)
     kwargs = {"limit": config.spotify.spotify_playlist_post_limit}
-    if subreddit.type == "top":
+    if subreddit.type == SubredditType.TOP:
         kwargs["time_filter"] = subreddit.period
     subs = [
         x
@@ -176,7 +178,7 @@ async def get_subreddit_posts(
             func(**kwargs), message="Failed to retrieve Reddit submission"
         )
     ]
-    msg = f'Filtering {len(subs)} "r/{subreddit.name}" {subreddit.type} posts'
+    msg = f'Filtering {len(subs)} "r/{subreddit.name}" {subreddit.type.value} posts'
     logger.info(msg)
     submissions = []
     for submission in tqdm(subs, desc=msg):

--- a/src/djtools/utils/config.py
+++ b/src/djtools/utils/config.py
@@ -5,8 +5,9 @@ config.yaml
 
 import logging
 import os
+from enum import Enum
 from pathlib import Path
-from typing import List, Literal, Optional, Union
+from typing import List, Optional, Union
 
 from pydantic import (
     field_validator,
@@ -14,6 +15,7 @@ from pydantic import (
     NonNegativeFloat,
     NonNegativeInt,
 )
+import yaml
 
 from djtools.configs.config_formatter import BaseConfigFormatter
 
@@ -21,14 +23,63 @@ from djtools.configs.config_formatter import BaseConfigFormatter
 logger = logging.getLogger(__name__)
 
 
+class AudioFormats(Enum):
+    # pylint: disable=missing-class-docstring
+    AAC = "aac"
+    AIFF = "aiff"
+    ALAC = "alac"
+    FLAC = "flac"
+    MP3 = "mp3"
+    OGG = "ogg"
+    PCM = "pcm"
+    WAV = "wav"
+    WMA = "wma"
+
+
+def audio_formats_representer(dumper, data):
+    # pylint: disable=missing-function-docstring
+    return dumper.represent_scalar("!AudioFormats", data.value)
+
+
+def audio_formats_constructor(loader, node):
+    # pylint: disable=missing-function-docstring
+    return AudioFormats(loader.construct_scalar(node))
+
+
+yaml.add_representer(AudioFormats, audio_formats_representer)
+yaml.add_constructor("!AudioFormats", audio_formats_constructor)
+
+
+class TrimInitialSilenceMode(Enum):
+    # pylint: disable=missing-class-docstring
+    AUTO = "auto"
+    SMART = "smart"
+
+
+def trim_initial_silence_mode_representer(dumper, data):
+    # pylint: disable=missing-function-docstring
+    return dumper.represent_scalar("!TrimInitialSilenceMode", data.value)
+
+
+def trim_initial_silence_mode_constructor(loader, node):
+    # pylint: disable=missing-function-docstring
+    return TrimInitialSilenceMode(loader.construct_scalar(node))
+
+
+yaml.add_representer(
+    TrimInitialSilenceMode, trim_initial_silence_mode_representer
+)
+yaml.add_constructor(
+    "!TrimInitialSilenceMode", trim_initial_silence_mode_constructor
+)
+
+
 class UtilsConfig(BaseConfigFormatter):
     """Configuration object for the utils package."""
 
     audio_bitrate: str = "320"
     audio_destination: Optional[Path] = None
-    audio_format: Literal[
-        "aac", "aiff", "alac", "flac", "mp3", "ogg", "pcm", "wav", "wma"
-    ] = "mp3"
+    audio_format: AudioFormats = AudioFormats.MP3
     audio_headroom: NonNegativeFloat = 0.0
     check_tracks: bool = False
     check_tracks_fuzz_ratio: NonNegativeInt = 80
@@ -38,7 +89,7 @@ class UtilsConfig(BaseConfigFormatter):
     process_recording: bool = False
     recording_file: Optional[Path] = None
     recording_playlist: str = ""
-    trim_initial_silence: Union[int, Literal["auto", "smart"]] = 0
+    trim_initial_silence: Union[int, TrimInitialSilenceMode] = 0
     url_download: str = ""
 
     def __init__(self, *args, **kwargs):

--- a/src/djtools/utils/config.py
+++ b/src/djtools/utils/config.py
@@ -58,12 +58,16 @@ class TrimInitialSilenceMode(Enum):
 
 def trim_initial_silence_mode_representer(dumper, data):
     # pylint: disable=missing-function-docstring
-    return dumper.represent_scalar("!TrimInitialSilenceMode", data.value)
+    return dumper.represent_scalar(  # pragma: no cover
+        "!TrimInitialSilenceMode", data.value
+    )
 
 
 def trim_initial_silence_mode_constructor(loader, node):
     # pylint: disable=missing-function-docstring
-    return TrimInitialSilenceMode(loader.construct_scalar(node))
+    return TrimInitialSilenceMode(  # pragma: no cover
+        loader.construct_scalar(node)
+    )
 
 
 yaml.add_representer(

--- a/src/djtools/utils/helpers.py
+++ b/src/djtools/utils/helpers.py
@@ -19,7 +19,6 @@ from typing import (
     Callable,
     Dict,
     List,
-    Literal,
     Optional,
     Set,
     Tuple,
@@ -33,6 +32,7 @@ from pydub import AudioSegment, effects, silence
 from tqdm import tqdm
 
 from djtools.spotify.helpers import get_playlist_ids, get_spotify_client
+from djtools.utils.config import TrimInitialSilenceMode
 
 
 logger = logging.getLogger(__name__)
@@ -393,7 +393,7 @@ def process_parallel(
         if config.sync.artist_first
         else f'{track["title"]} - {track["artist"]}'
     )
-    filename = write_path / f"{filename}.{config.utils.audio_format}"
+    filename = write_path / f"{filename}.{config.utils.audio_format.value}"
 
     # Warn users about malformed filenames that could break other features
     # of djtools.
@@ -409,7 +409,7 @@ def process_parallel(
     # data collected from the Spotify response.
     audio.export(
         filename,
-        format=config.utils.audio_format,
+        format=config.utils.audio_format.value,
         bitrate=f"{config.utils.audio_bitrate}k",
         tags={key: value for key, value in track.items() if key != "duration"},
     )
@@ -439,7 +439,7 @@ def reverse_title_and_artist(path_lookup: Dict[str, str]) -> Dict[str, str]:
 def trim_initial_silence(
     audio: AudioSegment,
     track_durations: List[int],
-    trim_amount: Union[int, Literal["auto", "smart"]],
+    trim_amount: Union[int, TrimInitialSilenceMode],
     silence_thresh: Optional[float] = -50,
     min_silence_ms: Optional[int] = 5,
     step_size: Optional[int] = 100,
@@ -474,7 +474,7 @@ def trim_initial_silence(
     )
 
     # If trim_amount is "auto", simply trim off the detected leading silence.
-    if trim_amount == "auto":
+    if trim_amount == TrimInitialSilenceMode.AUTO:
         return audio[leading_silence:]
 
     # Use the track durations to infer the points in the recording where each

--- a/tests/collection/test_helpers.py
+++ b/tests/collection/test_helpers.py
@@ -11,7 +11,11 @@ import pytest
 from djtools.collection.base_collection import Collection
 from djtools.collection.base_playlist import Playlist
 from djtools.collection.base_track import Track
-from djtools.collection.config import PlaylistConfigContent, PlaylistName
+from djtools.collection.config import (
+    PlaylistConfigContent,
+    PlaylistName,
+    RegisteredPlatforms,
+)
 from djtools.collection.helpers import (
     add_selectors_to_tags,
     aggregate_playlists,
@@ -59,7 +63,7 @@ def test_platform_registry_structure():
     required_class_impl_keys = {"collection", "playlist", "track"}
     required_base_class_impls = {Collection, Playlist, Track}
     for registered_software, impls in PLATFORM_REGISTRY.items():
-        assert isinstance(registered_software, str)
+        assert isinstance(registered_software, RegisteredPlatforms)
         assert isinstance(impls, dict)
         assert set(impls.keys()) == required_class_impl_keys
         assert (

--- a/tests/collection/test_playlist_builder.py
+++ b/tests/collection/test_playlist_builder.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 
+from djtools.collection.config import PlaylistRemainder
 from djtools.collection.playlist_builder import (
     collection_playlists,
     PLAYLIST_NAME,
@@ -12,7 +13,10 @@ from djtools.collection.rekordbox_collection import RekordboxCollection
 from djtools.collection.rekordbox_playlist import RekordboxPlaylist
 
 
-@pytest.mark.parametrize("remainder_type", ["folder", "playlist"])
+@pytest.mark.parametrize(
+    "remainder_type",
+    [PlaylistRemainder.FOLDER, PlaylistRemainder.PLAYLIST],
+)
 def test_collection_playlists_makes_unused_tags_playlists(
     remainder_type,
     config,
@@ -45,7 +49,7 @@ def test_collection_playlists_makes_unused_tags_playlists(
     assert collection.get_playlists("Unused Tags")
     unused_tags_playlists = collection.get_playlists("Unused Tags")[0]
 
-    if remainder_type == "folder":
+    if remainder_type == PlaylistRemainder.FOLDER:
         # If collection_playlists_remainder is set to "folder", then
         # "Unused Tags" will be a folder containing one playlist for each
         # unused tag.

--- a/tests/configs/test_base_config_formatter.py
+++ b/tests/configs/test_base_config_formatter.py
@@ -1,0 +1,101 @@
+"""Testing for the config_formatter module."""
+
+from unittest import mock
+
+from pydantic import ValidationError
+
+from djtools.configs.config_formatter import BaseConfigFormatter
+
+
+def test_base_config_formatter_repr():
+    """Define a sample subclass of BaseConfigFormatter for testing."""
+
+    class SampleConfig(BaseConfigFormatter):
+        """Dummy class."""
+
+        field1: int
+        field2: str
+
+    config = SampleConfig(field1=42, field2="test")
+    expected_repr = "SampleConfig(\n\tfield1=42\n\tfield2='test'\n)"
+    assert repr(config) == expected_repr
+
+
+def test_base_config_formatter_logging():
+    """Define a class named "BaseConfig" to trigger the logging behavior."""
+    with mock.patch("djtools.configs.config_formatter.logger") as mock_logger:
+
+        class BaseConfig(BaseConfigFormatter):
+            """Dummy class."""
+
+            field: str
+
+        _ = BaseConfig(field="test")
+        mock_logger.info.assert_called_once_with(
+            "BaseConfig(\n\tfield='test'\n)"
+        )
+
+
+def test_base_config_formatter_nested():
+    """Define nested configurations."""
+
+    class NestedConfig(BaseConfigFormatter):
+        """Dummy class."""
+
+        nested_field: int
+
+    class ParentConfig(BaseConfigFormatter):
+        """Dummy class."""
+
+        parent_field: str
+        nested: NestedConfig
+
+    nested_config = NestedConfig(nested_field=99)
+    parent_config = ParentConfig(parent_field="parent", nested=nested_config)
+
+    expected_repr = (
+        "ParentConfig(\n"
+        "\tparent_field='parent'\n"
+        "\tnested=NestedConfig(\n"
+        "\t\tnested_field=99\n"
+        "\t)\n"
+        ")"
+    )
+    assert repr(parent_config) == expected_repr
+
+
+def test_base_config_formatter_invalid():
+    """Ensure invalid input raises a ValidationError."""
+
+    class InvalidConfig(BaseConfigFormatter):
+        """Dummy class."""
+
+        field: int
+
+    try:
+        InvalidConfig(field="not an int")
+        assert False, "Expected ValidationError was not raised"
+    except ValidationError:
+        pass
+
+
+def test_base_config_formatter_list_of_dicts():
+    """Test __repr__ for a field with a list of dictionaries."""
+
+    class ConfigWithListOfDicts(BaseConfigFormatter):
+        """Dummy class."""
+
+        items: list[dict]
+
+    config = ConfigWithListOfDicts(
+        items=[{"key1": "value1"}, {"key2": "value2"}]
+    )
+    expected_repr = (
+        "ConfigWithListOfDicts(\n"
+        "\titems=[\n"
+        "\t\t{'key1': 'value1'},\n"
+        "\t\t{'key2': 'value2'}\n"
+        "\t]\n"
+        ")"
+    )
+    assert repr(config) == expected_repr

--- a/tests/configs/test_cli_args.py
+++ b/tests/configs/test_cli_args.py
@@ -13,6 +13,7 @@ from djtools.configs.cli_args import (
     get_arg_parser,
     NonEmptyListElementAction,
 )
+from djtools.utils.config import TrimInitialSilenceMode
 
 
 @pytest.mark.parametrize("paths", ["path", ["path1", "path2"]])
@@ -106,11 +107,11 @@ def test_parse_trim_initial_silence_int():
 
 def test_parse_trim_initial_silence_str():
     """Test for the _parse_trim_initial_silence function."""
-    arg = "auto"
-    assert isinstance(arg, str)
+    arg = TrimInitialSilenceMode.AUTO
+    assert isinstance(arg, TrimInitialSilenceMode)
     result = _parse_trim_initial_silence(arg)
-    assert isinstance(result, str)
-    assert result == "auto"
+    assert isinstance(result, TrimInitialSilenceMode)
+    assert result == TrimInitialSilenceMode.AUTO
 
 
 def test_parse_trim_initial_silence_invalid_str():

--- a/tests/configs/test_config.py
+++ b/tests/configs/test_config.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from djtools.configs.config import BaseConfig
+from djtools.configs.config import BaseConfig, LogLevel
 from djtools.spotify.config import SpotifyConfig
 
 
@@ -21,17 +21,17 @@ from djtools.spotify.config import SpotifyConfig
 )
 def test_baseconfig_limits_repr_in_cli_execution():
     """Test for the BaseConfig class."""
-    BaseConfig(key="value")
+    BaseConfig(verbosity=0)
 
 
 def test_baseconfig_repr_differentiates_baseconfig_and_subclasses():
     """Test for the BaseConfig class."""
     base_config = BaseConfig()
-    assert "log_level=INFO" in repr(base_config)
+    assert f"log_level={repr(LogLevel.INFO)}" in repr(base_config)
     assert "verbosity=0" in repr(base_config)
 
     spotify_config = SpotifyConfig()
-    assert "log_level=INFO" not in repr(spotify_config)
+    assert f"log_level={repr(LogLevel.INFO)}" not in repr(spotify_config)
     assert "verbosity=0" not in repr(spotify_config)
 
 

--- a/tests/configs/test_helpers.py
+++ b/tests/configs/test_helpers.py
@@ -9,6 +9,7 @@ from unittest import mock
 import pytest
 from pip._vendor import tomli
 
+from djtools.configs.config import LogLevel
 from djtools.configs.helpers import _arg_parse, build_config, ConfigLoadFailure
 from djtools.version import get_version
 
@@ -134,10 +135,10 @@ def test_build_config_no_config_yaml(
 @mock.patch("argparse.ArgumentParser.parse_args")
 def test_build_config_overrides_using_args(mock_parse_args, namespace):
     """Test for the build_config function."""
-    namespace.log_level = "CRITICAL"
+    namespace.log_level = LogLevel.CRITICAL.value
     mock_parse_args.return_value = namespace
     config = build_config()
-    assert config.log_level == "CRITICAL"
+    assert config.log_level == LogLevel.CRITICAL
 
 
 @mock.patch("argparse.ArgumentParser.parse_args")

--- a/tests/spotify/test_helpers.py
+++ b/tests/spotify/test_helpers.py
@@ -7,7 +7,7 @@ from unittest import mock
 import pytest
 import yaml
 
-from djtools.spotify.config import SubredditConfig
+from djtools.spotify.config import SubredditConfig, SubredditType
 from djtools.spotify.helpers import (
     _build_new_playlist,
     _catch,
@@ -374,7 +374,9 @@ def test_get_spotify_client(is_spotify_config, config):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("subreddit_type", ["hot", "top"])
+@pytest.mark.parametrize(
+    "subreddit_type", [SubredditType.HOT, SubredditType.TOP]
+)
 @pytest.mark.parametrize("num_subs", [5, 0])
 @mock.patch("djtools.spotify.helpers.praw.Reddit.close", mock.Mock())
 @mock.patch("djtools.spotify.helpers._process")
@@ -411,7 +413,7 @@ async def test_get_subreddit_posts(
             mock_spotify, mock_praw, subreddit, config, praw_cache
         )
     assert caplog.records[0].message == (
-        f'Filtering {num_subs} "r/techno" {subreddit_type} posts'
+        f'Filtering {num_subs} "r/techno" {subreddit_type.value} posts'
     )
     if not num_subs:
         assert caplog.records[1].message == (

--- a/tests/sync/test_config.py
+++ b/tests/sync/test_config.py
@@ -148,19 +148,14 @@ def test_syncconfig_set_user(input_user, output_user):
 
 
 @mock.patch("djtools.spotify.helpers.get_spotify_client", mock.MagicMock())
-def test_syncconfig_upload_without_discord_url(rekordbox_xml, caplog):
+def test_syncconfig_upload_without_discord_url(caplog):
     """Test for the SyncConfig class."""
     caplog.set_level("WARNING")
     cfg = {
-        "usb_path": ".",
-        "upload_music": True,
         "bucket_url": "s3://some-bucket.com",
         "discord_url": "",
-        "collection_path": rekordbox_xml,
-        "spotify_client_id": "id",
-        "spotify_client_secret": "secret",
-        "spotify_redirect_uri": "uri",
-        "spotify_username": "name",
+        "upload_music": True,
+        "usb_path": ".",
     }
     SyncConfig(**cfg)
     assert caplog.records[0].message == (

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -28,7 +28,6 @@ def test_utilsconfig_spotify_creds_warning(caplog):
     cfg = {
         "check_tracks": True,
         "check_tracks_spotify_playlists": ["playlist"],
-        "aws_profile": "default",
     }
     os.environ["AWS_PROFILE"] = "default"  # pylint: disable=no-member
     UtilsConfig(**cfg)

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -9,6 +9,7 @@ from unittest import mock
 import pytest
 from pydub import AudioSegment, generators
 
+from djtools.utils.config import TrimInitialSilenceMode
 from djtools.utils.helpers import (
     compute_distance,
     find_matches,
@@ -336,7 +337,16 @@ def test_reverse_title_and_artist():
     assert new_path_lookup == expected
 
 
-@pytest.mark.parametrize("trim_amount", [-1000, 0, 1000, "auto", "smart"])
+@pytest.mark.parametrize(
+    "trim_amount",
+    [
+        -1000,
+        0,
+        1000,
+        TrimInitialSilenceMode.AUTO,
+        TrimInitialSilenceMode.SMART,
+    ],
+)
 def test_trim_initial_silence(trim_amount):
     """Test for the trim_initial_silence function."""
     leading_silence = 4567
@@ -368,7 +378,7 @@ def test_trim_initial_silence(trim_amount):
     diff = init_len - len(audio)
     if isinstance(trim_amount, int):
         assert abs(diff - trim_amount) <= 1
-    elif trim_amount == "auto":
+    elif trim_amount == TrimInitialSilenceMode.AUTO:
         assert abs(diff - leading_silence) <= 1
     else:
         assert abs(leading_silence - silence_len - diff) <= step_size * 2


### PR DESCRIPTION
feat
- improve config repr

fix
- playlist builder to ack PlaylistFilter enum and making the playlist config a config attribute
- have all CLI args present when instantiating configs so validation works properly
- scripts updated to work with config refactor

test    
- coverage for config_formatter
- fix fixture usage after config reformat
- ignore coverage on YAML representer